### PR TITLE
Address build warning messages found while building rdkit

### DIFF
--- a/Buffer.cpp
+++ b/Buffer.cpp
@@ -131,8 +131,10 @@ bool BufferDataCollector::load(BufferData& data, const char* begin,
     return succeeded;
 }
 
-size_t BufferDataCollector::readData(char* ptr, size_t size) const
+size_t BufferDataCollector::readData(char*, size_t) const
 {
+    // char* ptr, size_t size are unnamed to avoid compilation warning messages.
+
     // The BufferDataCollector doesn't actually read any data directly; it
     // delegates that to its member BufferLoader instance.
     return 0;

--- a/MaeParser.cpp
+++ b/MaeParser.cpp
@@ -24,11 +24,13 @@ static std::string outer_block_name(Buffer& buffer);
 void read_exception::format(int line_number, int column, const char* msg)
 {
 #ifdef _MSC_VER
-    _snprintf(m_msg, MAEPARSER_EXCEPTION_BUFFER_SIZE, "Line %d, column %d: %s\n", line_number,
+    _snprintf(m_msg, MAEPARSER_EXCEPTION_BUFFER_SIZE,
+              "Line %d, column %d: %s\n", line_number,
 #else
-    snprintf(m_msg, MAEPARSER_EXCEPTION_BUFFER_SIZE, "Line %d, column %d: %s\n", line_number,
+    snprintf(m_msg, MAEPARSER_EXCEPTION_BUFFER_SIZE, "Line %d, column %d: %s\n",
+             line_number,
 #endif
-             column, msg);
+              column, msg);
     m_msg[MAEPARSER_EXCEPTION_BUFFER_SIZE - 1] = '\0';
 }
 
@@ -175,7 +177,8 @@ done:
     return value;
 }
 
-template <> EXPORT_MAEPARSER std::string parse_value<std::string>(Buffer& buffer)
+template <>
+EXPORT_MAEPARSER std::string parse_value<std::string>(Buffer& buffer)
 {
     char* save = buffer.current;
     if (*buffer.current != '"') {
@@ -545,7 +548,7 @@ void DirectIndexedBlockParser::parse(const std::string& name, size_t size,
         parsers.push_back(p);
     }
 
-    for (int i = 0; i < size; ++i) {
+    for (size_t i = 0; i < size; ++i) {
         for (auto parser : parsers) {
             whitespace(buffer);
             parser->parse(buffer);


### PR DESCRIPTION
Also clang-formatted the affected files accidentally, but these are Schrödinger's current internal clang-format settings, so I'm leaving the changes in the diff.

These are the errors I observed:
```
rdkit/External/CoordGen/maeparser/Buffer.cpp:134:44: warning: unused parameter 'ptr' [-Wunused-parameter]
size_t BufferDataCollector::readData(char* ptr, size_t size) const
                                           ^
rdkit/External/CoordGen/maeparser/Buffer.cpp:134:56: warning: unused parameter 'size' [-Wunused-parameter]
size_t BufferDataCollector::readData(char* ptr, size_t size) const
                                                       ^
2 warnings generated.
[  0%] Building CXX object External/CoordGen/CMakeFiles/maeparser.dir/maeparser/MaeBlock.cpp.o
[  0%] Building CXX object External/CoordGen/CMakeFiles/maeparser.dir/maeparser/MaeParser.cpp.o
dkit/External/CoordGen/maeparser/MaeParser.cpp:546:23: warning: comparison of integers of different signs: 'int' and 'size_t' (aka 'unsigned long') [-Wsign-compare]
    for (int i = 0; i < size; ++i) {
                    ~ ^ ~~~~
1 warning generated.
```