### PR TITLE
Add has*Property to Indexed Blocks

### DIFF
--- a/MaeBlock.hpp
+++ b/MaeBlock.hpp
@@ -362,6 +362,11 @@ class EXPORT_MAEPARSER IndexedBlock
     void setProperty(const std::string& name,
                      std::shared_ptr<IndexedProperty<T>> value);
 
+    bool hasBoolProperty(const std::string& name) const
+    {
+        return (m_bmap.find(name) != m_bmap.end());
+    }
+
     std::shared_ptr<IndexedBoolProperty>
     getBoolProperty(const std::string& name) const
     {
@@ -372,6 +377,11 @@ class EXPORT_MAEPARSER IndexedBlock
                          const std::shared_ptr<IndexedBoolProperty> value)
     {
         set_indexed_property<IndexedBoolProperty>(m_bmap, name, value);
+    }
+
+    bool hasIntProperty(const std::string& name) const
+    {
+        return (m_imap.find(name) != m_imap.end());
     }
 
     std::shared_ptr<IndexedIntProperty>
@@ -386,6 +396,11 @@ class EXPORT_MAEPARSER IndexedBlock
         set_indexed_property<IndexedIntProperty>(m_imap, name, value);
     }
 
+    bool hasRealProperty(const std::string& name) const
+    {
+        return (m_rmap.find(name) != m_rmap.end());
+    }
+
     std::shared_ptr<IndexedRealProperty>
     getRealProperty(const std::string& name) const
     {
@@ -396,6 +411,11 @@ class EXPORT_MAEPARSER IndexedBlock
                          const std::shared_ptr<IndexedRealProperty> value)
     {
         set_indexed_property<IndexedRealProperty>(m_rmap, name, value);
+    }
+
+    bool hasStringProperty(const std::string& name) const
+    {
+        return (m_smap.find(name) != m_smap.end());
     }
 
     std::shared_ptr<IndexedStringProperty>

--- a/test/MaeBlockTest.cpp
+++ b/test/MaeBlockTest.cpp
@@ -104,10 +104,12 @@ BOOST_AUTO_TEST_CASE(maeIndexedBlock)
         dv.push_back(0.0);
         dv.push_back(3.0);
         IndexedBlock ib("m_atom");
+        BOOST_REQUIRE(!ib.hasRealProperty("r_m_float"));
         auto irps = std::shared_ptr<IndexedRealProperty>(
             new IndexedRealProperty(dv, bs));
 
         ib.setRealProperty("r_m_float", irps);
+        BOOST_REQUIRE(ib.hasRealProperty("r_m_float"));
 
         auto irpg = ib.getRealProperty("r_m_float");
         IndexedRealProperty& irp = *irpg;
@@ -117,6 +119,7 @@ BOOST_AUTO_TEST_CASE(maeIndexedBlock)
         BOOST_REQUIRE_THROW(irp[1], std::runtime_error);
         BOOST_REQUIRE(irp.isDefined(2));
         BOOST_REQUIRE_CLOSE(irp[2], 3.0, tolerance);
+
     }
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/MaeBlockTest.cpp
+++ b/test/MaeBlockTest.cpp
@@ -119,7 +119,6 @@ BOOST_AUTO_TEST_CASE(maeIndexedBlock)
         BOOST_REQUIRE_THROW(irp[1], std::runtime_error);
         BOOST_REQUIRE(irp.isDefined(2));
         BOOST_REQUIRE_CLOSE(irp[2], 3.0, tolerance);
-
     }
 }
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This existed on Blocks but not Indexed blocks for some reason.  W/o this it requires try/excepts around getProperty.