### PR TITLE
allow static builds on windows

### DIFF
--- a/MaeParserConfig.hpp
+++ b/MaeParserConfig.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#ifndef STATIC_MAEPARSER
+
 #ifdef IN_MAEPARSER
 
 #ifdef WIN32
@@ -18,3 +20,8 @@
 
 #endif
 
+#else
+
+#define EXPORT_MAEPARSER
+
+#endif


### PR DESCRIPTION
On the RDKit side we often need to build the backend libraries statically linked. This enables that for maeparser on Windows.
It's connected to https://github.com/rdkit/rdkit/pull/1910.