### PR TITLE
SOVERSION+VERSION library properties

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,11 @@ find_package(Boost COMPONENTS iostreams unit_test_framework REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 
 add_library(maeparser SHARED Buffer.cpp MaeBlock.cpp MaeParser.cpp Reader.cpp)
+SET_TARGET_PROPERTIES (maeparser
+    PROPERTIES
+       VERSION 1.0.1
+       SOVERSION 1
+)
 target_link_libraries(maeparser Boost::disable_autolinking Boost::dynamic_linking Boost::iostreams)
 
 target_include_directories(maeparser PUBLIC


### PR DESCRIPTION
This patch was promised in https://github.com/schrodinger/maeparser/issues/22. It works nicely over here.

The SONAME, which indicates compatibility between binary library files, now gets a .1 version suffix, set equal to the major version of your project. This becomes a symbolic link to the real library file that contains a full version string as a suffix. This way, you can install multiple versions in parallel. The ldconfig tool will by default link to the latest version physically available and Linux distributions will also only offer the latest version of a given SONAME.