### PR TITLE
Bump minimum version of cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 set (CMAKE_CXX_STANDARD 11)
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.5)
 
 project(maeparser)
 


### PR DESCRIPTION
This is needed for FindBoost features we use.