### PR TITLE
Add a Maestro format writer and appropriate tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ drop_cache
 boost
 unittest
 env.sh
+test_write.mae*

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ boost
 unittest
 env.sh
 test_write.mae*
+#Vim temporary files
+*~

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(Boost COMPONENTS iostreams unit_test_framework REQUIRED)
 
 include_directories(${Boost_INCLUDE_DIRS})
 
-add_library(maeparser SHARED Buffer.cpp MaeBlock.cpp MaeParser.cpp Reader.cpp)
+add_library(maeparser SHARED Buffer.cpp MaeBlock.cpp MaeParser.cpp Reader.cpp Writer.cpp)
 SET_TARGET_PROPERTIES (maeparser
     PROPERTIES
        VERSION 1.0.1

--- a/MaeBlock.cpp
+++ b/MaeBlock.cpp
@@ -359,8 +359,6 @@ static bool maps_indexed_props_equal(const T& lmap, const T& rmap)
 
 bool IndexedBlock::operator==(const IndexedBlock& rhs) const
 {
-    using namespace std;
-
     if(!maps_indexed_props_equal(m_bmap, rhs.m_bmap)) return false;
     if(!maps_indexed_props_equal(m_imap, rhs.m_imap)) return false;
     if(!maps_indexed_props_equal(m_rmap, rhs.m_rmap)) return false;

--- a/MaeBlock.cpp
+++ b/MaeBlock.cpp
@@ -24,7 +24,7 @@ static string local_to_string(string val)
     // Create new string big enough to escape every character and add quotes
     int pos_in_old = 0;
     bool escaped_char = false;
-    for(; pos_in_old<val.length(); pos_in_old++) {
+    for(; pos_in_old<val.length(); ++pos_in_old) {
         const char& c = val[pos_in_old];
         if(c == '"' || c == '\\' || c == ' ') {
             escaped_char = true;
@@ -35,7 +35,7 @@ static string local_to_string(string val)
 
     int pos_in_new = 1;
     string new_string(val.length()*2 + 2, '\"');
-    for(pos_in_old = 0; pos_in_old<val.length(); pos_in_old++)
+    for(pos_in_old = 0; pos_in_old<val.length(); ++pos_in_old)
     {
         const char& c = val[pos_in_old];
         if(c == '"' || c == '\\') {
@@ -120,17 +120,18 @@ string Block::toString() const
 }
 
 
-shared_ptr<IndexedBlock> Block::getIndexedBlock(const string& name)
+shared_ptr<const IndexedBlock> Block::getIndexedBlock(const string& name)
 {
     if(!hasIndexedBlockData()) {
         throw out_of_range("Indexed block not found: " + name);
     }
-    return m_indexed_block_map->getIndexedBlock(name);
+    return const_pointer_cast<const IndexedBlock>(m_indexed_block_map->getIndexedBlock(name));
 }
 
-bool rmap_equal(map<string, double> rmap1,
+bool real_map_equal(map<string, double> rmap1,
         map<string, double> rmap2)
 {
+    if(rmap1.size() != rmap2.size()) return false;
     for(const auto& p : rmap1) {
         if(rmap2.count(p.first) != 1) return false;
         if(abs(p.second - rmap2[p.first]) > tolerance) return false;
@@ -142,7 +143,7 @@ bool rmap_equal(map<string, double> rmap1,
 bool Block::operator==(const Block& rhs) const
 {
     if(m_bmap != rhs.m_bmap) return false;
-    if(!rmap_equal(m_rmap, rhs.m_rmap)) return false;
+    if(!real_map_equal(m_rmap, rhs.m_rmap)) return false;
     if(m_imap != rhs.m_imap) return false;
     if(m_smap != rhs.m_smap) return false;
     if(m_sub_block != rhs.m_sub_block) return false;
@@ -168,13 +169,13 @@ bool IndexedBlockMap::hasIndexedBlock(const string& name) const
     return m_indexed_block.find(name) != m_indexed_block.end();
 }
 
-shared_ptr<IndexedBlock>
+shared_ptr<const IndexedBlock>
 IndexedBlockMap::getIndexedBlock(const string& name) const
 {
-    map<string, shared_ptr<IndexedBlock>>::const_iterator itb =
+    map<string,shared_ptr<IndexedBlock>>::const_iterator block_iter =
         m_indexed_block.find(name);
-    if (itb != m_indexed_block.end()) {
-        return itb->second;
+    if (block_iter != m_indexed_block.end()) {
+        return const_pointer_cast<const IndexedBlock>(block_iter->second);
     } else {
         throw out_of_range("Indexed block not found: " + name);
     }
@@ -191,7 +192,7 @@ bool BufferedIndexedBlockMap::hasIndexedBlock(const string& name) const
     }
 }
 
-shared_ptr<IndexedBlock>
+shared_ptr<const IndexedBlock>
 BufferedIndexedBlockMap::getIndexedBlock(const string& name) const
 {
     map<string, shared_ptr<IndexedBlock>>::const_iterator itb =
@@ -204,7 +205,7 @@ BufferedIndexedBlockMap::getIndexedBlock(const string& name) const
     if (itbb == m_indexed_buffer.end()) {
         throw out_of_range("Indexed block not found: " + name);
     } else {
-        shared_ptr<IndexedBlock> ib(itbb->second->getIndexedBlock());
+        shared_ptr<const IndexedBlock> ib(itbb->second->getIndexedBlock());
         return ib;
     }
 }
@@ -242,6 +243,7 @@ EXPORT_MAEPARSER void IndexedBlock::setProperty<string>(
 size_t IndexedBlock::size() const
 {
     size_t count = 0;
+    // Counts of these maps are 1:1 with properties in the map
     for(const auto& p : m_bmap) count = max(p.second->size(), count);
     for(const auto& p : m_imap) count = max(p.second->size(), count);
     for(const auto& p : m_rmap) count = max(p.second->size(), count);
@@ -287,7 +289,7 @@ void IndexedBlock::write(ostream& out, unsigned int current_indentation) const
         out << indentation + ":::\n";
     }
 
-    for(unsigned int i=0; i<size(); i++) {
+    for(unsigned int i=0; i<size(); ++i) {
         out << indentation << i+1;
         output_indexed_property_values(out, indentation, m_bmap, i);
         output_indexed_property_values(out, indentation, m_rmap, i);
@@ -333,42 +335,36 @@ bool IndexedProperty<double>::operator==(const IndexedProperty<double>& rhs) con
 {
     if(m_is_null == nullptr || rhs.m_is_null == nullptr) {
         if((m_is_null == nullptr) != (rhs.m_is_null == nullptr)) return false;
-    } else if(*m_is_null != *(rhs.m_is_null)) {
-        return false;
-    }
-    for(int i=0; i<m_data.size(); i++)
+    } else if(*m_is_null != *(rhs.m_is_null)) return false;
+
+    for(int i=0; i<m_data.size(); ++i)
         if(abs(m_data[i] - rhs.m_data[i]) > tolerance) return false;
 
     return true;
 }
 
+template <typename T>
+static bool maps_indexed_props_equal(const T& lmap, const T& rmap)
+{
+    for(const auto& p : lmap) {
+        if(rmap.size() != lmap.size()) return false;
+        auto diff = std::mismatch(lmap.begin(), lmap.end(), rmap.begin(),
+                 [](decltype(*begin(lmap)) l, decltype(*begin(lmap)) r)
+                 {return l.first == r.first && *(l.second) == *(r.second);});
+        if (diff.first != lmap.end()) return false;
+    }
+    return true;
+}
+
+
 bool IndexedBlock::operator==(const IndexedBlock& rhs) const
 {
     using namespace std;
 
-    for(const auto& p : m_bmap) {
-        if(rhs.m_bmap.count(p.first) != 1) return false;
-        const auto& bmap2 = rhs.m_bmap.find(p.first);
-        if(!(*(bmap2->second) == *(p.second))) return false;
-    }
-
-    for(const auto& p : m_imap) {
-        if(rhs.m_imap.count(p.first) != 1) return false;
-        const auto& imap2 = rhs.m_imap.find(p.first);
-        if(!(*(imap2->second) == *(p.second))) return false;
-    }
-
-    for(const auto& p : m_rmap) {
-        if(rhs.m_rmap.count(p.first) != 1) return false;
-        const auto& rmap2 = rhs.m_rmap.find(p.first);
-        if(!(*(rmap2->second) == *(p.second))) return false;
-    }
-
-    for(const auto& p : m_smap) {
-        if(rhs.m_smap.count(p.first) != 1) return false;
-        const auto& smap2 = rhs.m_smap.find(p.first);
-        if(!(*(smap2->second) == *(p.second))) return false;
-    }
+    if(!maps_indexed_props_equal(m_bmap, rhs.m_bmap)) return false;
+    if(!maps_indexed_props_equal(m_imap, rhs.m_imap)) return false;
+    if(!maps_indexed_props_equal(m_rmap, rhs.m_rmap)) return false;
+    if(!maps_indexed_props_equal(m_smap, rhs.m_smap)) return false;
 
     return true;
 }

--- a/MaeBlock.cpp
+++ b/MaeBlock.cpp
@@ -1,39 +1,186 @@
 #include "MaeBlock.hpp"
 #include "MaeParser.hpp"
 
+using namespace std;
+
 namespace schrodinger
 {
 namespace mae
 {
+
+static const double tolerance = 0.00001; // Tolerance to match string cutoff
+
+
+// Wrap to-string to allow it to take strings and be a no-op
+template <typename T>
+static string local_to_string(T val)
+{
+    return to_string(val);
+}
+
+static string local_to_string(string val)
+{
+    if(val.length() == 0) return R"("")";
+    // Create new string big enough to escape every character and add quotes
+    int pos_in_old = 0;
+    bool escaped_char = false;
+    for(; pos_in_old<val.length(); pos_in_old++) {
+        const char& c = val[pos_in_old];
+        if(c == '"' || c == '\\' || c == ' ') {
+            escaped_char = true;
+            break;
+        }
+    }
+    if(!escaped_char) return val;
+
+    int pos_in_new = 1;
+    string new_string(val.length()*2 + 2, '\"');
+    for(pos_in_old = 0; pos_in_old<val.length(); pos_in_old++)
+    {
+        const char& c = val[pos_in_old];
+        if(c == '"' || c == '\\') {
+            new_string[pos_in_new++] = '\\';
+        }
+        new_string[pos_in_new++] = val[pos_in_old];
+    }
+    new_string.resize(pos_in_new+1);
+    return new_string;
+}
+
+template <typename T>
+static void output_property_names(ostream& out,
+        const string& indentation, map<string, T> properties)
+{
+    for(const auto& p : properties) {
+        out << indentation << p.first << "\n";
+    }
+}
+
+template <typename T>
+static void output_property_values(ostream& out,
+        const string& indentation, map<string, T> properties)
+{
+    for(const auto& p : properties) {
+        out << indentation << local_to_string(p.second) << "\n";
+    }
+}
 
 Block::~Block()
 {
     // TODO: check with valgrind whether some destructor is needed
 }
 
-std::shared_ptr<IndexedBlock> Block::getIndexedBlock(const std::string& name)
+void Block::write(ostream& out, unsigned int current_indentation) const
 {
+
+    string root_indentation = string(current_indentation, ' ');
+    string indentation = string(current_indentation+2, ' ');
+
+    out << root_indentation << getName() << " {\n";
+
+    output_property_names(out, indentation, m_bmap);
+    output_property_names(out, indentation, m_rmap);
+    output_property_names(out, indentation, m_imap);
+    output_property_names(out, indentation, m_smap);
+
+    if(m_bmap.size() + m_rmap.size() + m_imap.size() + m_smap.size() > 0) {
+        out << indentation + ":::\n";
+    }
+
+    output_property_values(out, indentation, m_bmap);
+    output_property_values(out, indentation, m_rmap);
+    output_property_values(out, indentation, m_imap);
+    output_property_values(out, indentation, m_smap);
+
+    if(hasIndexedBlockData()) {
+        const auto block_names = m_indexed_block_map->getBlockNames();
+        for(const auto& name : block_names) {
+            const auto& indexed_block = m_indexed_block_map->getIndexedBlock(name);
+            indexed_block->write(out, current_indentation+2);
+        }
+    }
+
+    for(const auto& p : m_sub_block) {
+        const auto& sub_block = p.second;
+        sub_block->write(out, current_indentation+2);
+    }
+
+
+    out << root_indentation << "}\n\n";
+
+    return;
+}
+
+string Block::toString() const
+{
+    ostringstream stream;
+    write(stream);
+
+    return stream.str();
+}
+
+
+shared_ptr<IndexedBlock> Block::getIndexedBlock(const string& name)
+{
+    if(!hasIndexedBlockData()) {
+        throw out_of_range("Indexed block not found: " + name);
+    }
     return m_indexed_block_map->getIndexedBlock(name);
 }
 
-bool IndexedBlockMap::hasIndexedBlock(const std::string& name)
+bool rmap_equal(map<string, double> rmap1,
+        map<string, double> rmap2)
+{
+    for(const auto& p : rmap1) {
+        if(rmap2.count(p.first) != 1) return false;
+        if(abs(p.second - rmap2[p.first]) > tolerance) return false;
+    }
+
+    return true;
+}
+
+bool Block::operator==(const Block& rhs) const
+{
+    if(m_bmap != rhs.m_bmap) return false;
+    if(!rmap_equal(m_rmap, rhs.m_rmap)) return false;
+    if(m_imap != rhs.m_imap) return false;
+    if(m_smap != rhs.m_smap) return false;
+    if(m_sub_block != rhs.m_sub_block) return false;
+    if(!(*m_indexed_block_map == *(rhs.m_indexed_block_map))) return false;
+    return true;
+}
+
+
+bool IndexedBlockMapI::operator==(const IndexedBlockMapI& rhs)
+{
+    const auto& block_names = getBlockNames();
+    for(const auto& name : block_names) {
+        if(!rhs.hasIndexedBlock(name)) return false;
+        const auto& block1 = rhs.getIndexedBlock(name);
+        const auto& block2 = getIndexedBlock(name);
+        if(*block1 != *block2) return false;
+    }
+    return true;
+}
+
+bool IndexedBlockMap::hasIndexedBlock(const string& name) const
 {
     return m_indexed_block.find(name) != m_indexed_block.end();
 }
 
-std::shared_ptr<IndexedBlock>
-IndexedBlockMap::getIndexedBlock(const std::string& name)
+shared_ptr<IndexedBlock>
+IndexedBlockMap::getIndexedBlock(const string& name) const
 {
-    std::map<std::string, std::shared_ptr<IndexedBlock>>::const_iterator itb =
+    map<string, shared_ptr<IndexedBlock>>::const_iterator itb =
         m_indexed_block.find(name);
     if (itb != m_indexed_block.end()) {
         return itb->second;
     } else {
-        throw std::out_of_range("Indexed block not found: " + name);
+        throw out_of_range("Indexed block not found: " + name);
     }
 }
 
-bool BufferedIndexedBlockMap::hasIndexedBlock(const std::string& name)
+bool BufferedIndexedBlockMap::hasIndexedBlock(const string& name) const
 {
     if (m_indexed_buffer.find(name) != m_indexed_buffer.end()) {
         return true;
@@ -44,10 +191,10 @@ bool BufferedIndexedBlockMap::hasIndexedBlock(const std::string& name)
     }
 }
 
-std::shared_ptr<IndexedBlock>
-BufferedIndexedBlockMap::getIndexedBlock(const std::string& name)
+shared_ptr<IndexedBlock>
+BufferedIndexedBlockMap::getIndexedBlock(const string& name) const
 {
-    std::map<std::string, std::shared_ptr<IndexedBlock>>::const_iterator itb =
+    map<string, shared_ptr<IndexedBlock>>::const_iterator itb =
         m_indexed_block.find(name);
     if (itb != m_indexed_block.end()) {
         return itb->second;
@@ -55,42 +202,175 @@ BufferedIndexedBlockMap::getIndexedBlock(const std::string& name)
 
     auto itbb = m_indexed_buffer.find(name);
     if (itbb == m_indexed_buffer.end()) {
-        throw std::out_of_range("Indexed block not found: " + name);
+        throw out_of_range("Indexed block not found: " + name);
     } else {
-        std::shared_ptr<IndexedBlock> ib(itbb->second->getIndexedBlock());
-        m_indexed_buffer.erase(itbb);
+        shared_ptr<IndexedBlock> ib(itbb->second->getIndexedBlock());
         return ib;
     }
 }
 
 template <>
 EXPORT_MAEPARSER void IndexedBlock::setProperty<BoolProperty>(
-    const std::string& name, std::shared_ptr<IndexedBoolProperty> value)
+    const string& name, shared_ptr<IndexedBoolProperty> value)
 {
     set_indexed_property<IndexedBoolProperty>(m_bmap, name, value);
 }
 
 template <>
 EXPORT_MAEPARSER void IndexedBlock::setProperty<double>(
-    const std::string& name, std::shared_ptr<IndexedProperty<double>> value)
+    const string& name, shared_ptr<IndexedProperty<double>> value)
 {
     set_indexed_property<IndexedProperty<double>>(m_rmap, name, value);
 }
 
 template <>
 EXPORT_MAEPARSER void
-IndexedBlock::setProperty<int>(const std::string& name,
-                               std::shared_ptr<IndexedProperty<int>> value)
+IndexedBlock::setProperty<int>(const string& name,
+                               shared_ptr<IndexedProperty<int>> value)
 {
     set_indexed_property<IndexedProperty<int>>(m_imap, name, value);
 }
 
 template <>
-EXPORT_MAEPARSER void IndexedBlock::setProperty<std::string>(
-    const std::string& name,
-    std::shared_ptr<IndexedProperty<std::string>> value)
+EXPORT_MAEPARSER void IndexedBlock::setProperty<string>(
+    const string& name,
+    shared_ptr<IndexedProperty<string>> value)
 {
-    set_indexed_property<IndexedProperty<std::string>>(m_smap, name, value);
+    set_indexed_property<IndexedProperty<string>>(m_smap, name, value);
+}
+
+size_t IndexedBlock::size() const
+{
+    size_t count = 0;
+    for(const auto& p : m_bmap) count = max(p.second->size(), count);
+    for(const auto& p : m_imap) count = max(p.second->size(), count);
+    for(const auto& p : m_rmap) count = max(p.second->size(), count);
+    for(const auto& p : m_smap) count = max(p.second->size(), count);
+
+    return count;
+}
+
+
+template <typename T>
+static void output_indexed_property_values(ostream& out,
+        const string& indentation, map<string, T> properties,
+        unsigned int index)
+{
+    for(const auto& p : properties) {
+        const auto& property = p.second;
+        if(property->isDefined(index)) {
+            out << " " << local_to_string(property->at(index));
+        } else {
+            out << " <>";
+        }
+    }
+}
+
+void IndexedBlock::write(ostream& out, unsigned int current_indentation) const
+{
+    string root_indentation = string(current_indentation, ' ');
+    string indentation = string(current_indentation+2, ' ');
+    const bool has_data = m_bmap.size() + m_rmap.size() + m_imap.size() + m_smap.size() > 0;
+
+    out << root_indentation << getName() << "[" << to_string((int)size()) << "] {\n";
+
+    if(has_data) {
+        out << indentation + "# First column is Index #\n";
+    }
+
+    output_property_names(out, indentation, m_bmap);
+    output_property_names(out, indentation, m_rmap);
+    output_property_names(out, indentation, m_imap);
+    output_property_names(out, indentation, m_smap);
+
+    if(has_data) {
+        out << indentation + ":::\n";
+    }
+
+    for(unsigned int i=0; i<size(); i++) {
+        out << indentation << i+1;
+        output_indexed_property_values(out, indentation, m_bmap, i);
+        output_indexed_property_values(out, indentation, m_rmap, i);
+        output_indexed_property_values(out, indentation, m_imap, i);
+        output_indexed_property_values(out, indentation, m_smap, i);
+        out << endl;
+    }
+
+    if(has_data) {
+        out << indentation + ":::\n";
+    }
+
+    out << root_indentation << "}\n";
+
+    return;
+}
+
+string IndexedBlock::toString() const
+{
+    ostringstream stream;
+    write(stream);
+
+    return stream.str();
+}
+
+template <typename T>
+bool IndexedProperty<T>::operator==(const IndexedProperty<T>& rhs) const
+{
+    if(m_is_null == nullptr || rhs.m_is_null == nullptr) {
+        if((m_is_null == nullptr) != (rhs.m_is_null == nullptr)) return false;
+    } else if(*m_is_null != *(rhs.m_is_null)) {
+        return false;
+    }
+    if(m_data != rhs.m_data) return false;
+    return true;
+}
+
+
+// For doubles we need to implement our own comparator for the vectors to
+// take precision into account
+template <>
+bool IndexedProperty<double>::operator==(const IndexedProperty<double>& rhs) const
+{
+    if(m_is_null == nullptr || rhs.m_is_null == nullptr) {
+        if((m_is_null == nullptr) != (rhs.m_is_null == nullptr)) return false;
+    } else if(*m_is_null != *(rhs.m_is_null)) {
+        return false;
+    }
+    for(int i=0; i<m_data.size(); i++)
+        if(abs(m_data[i] - rhs.m_data[i]) > tolerance) return false;
+
+    return true;
+}
+
+bool IndexedBlock::operator==(const IndexedBlock& rhs) const
+{
+    using namespace std;
+
+    for(const auto& p : m_bmap) {
+        if(rhs.m_bmap.count(p.first) != 1) return false;
+        const auto& bmap2 = rhs.m_bmap.find(p.first);
+        if(!(*(bmap2->second) == *(p.second))) return false;
+    }
+
+    for(const auto& p : m_imap) {
+        if(rhs.m_imap.count(p.first) != 1) return false;
+        const auto& imap2 = rhs.m_imap.find(p.first);
+        if(!(*(imap2->second) == *(p.second))) return false;
+    }
+
+    for(const auto& p : m_rmap) {
+        if(rhs.m_rmap.count(p.first) != 1) return false;
+        const auto& rmap2 = rhs.m_rmap.find(p.first);
+        if(!(*(rmap2->second) == *(p.second))) return false;
+    }
+
+    for(const auto& p : m_smap) {
+        if(rhs.m_smap.count(p.first) != 1) return false;
+        const auto& smap2 = rhs.m_smap.find(p.first);
+        if(!(*(smap2->second) == *(p.second))) return false;
+    }
+
+    return true;
 }
 
 } // namespace mae

--- a/MaeBlock.hpp
+++ b/MaeBlock.hpp
@@ -36,7 +36,7 @@ class EXPORT_MAEPARSER IndexedBlockMapI
   public:
     virtual ~IndexedBlockMapI(){};
     virtual bool hasIndexedBlock(const std::string& name) const = 0;
-    virtual std::shared_ptr<IndexedBlock>
+    virtual std::shared_ptr<const IndexedBlock>
     getIndexedBlock(const std::string& name) const = 0;
 
     virtual std::vector<std::string> getBlockNames() const = 0;
@@ -50,7 +50,7 @@ class EXPORT_MAEPARSER IndexedBlockMap : public IndexedBlockMapI
   public:
     virtual bool hasIndexedBlock(const std::string& name) const;
 
-    virtual std::shared_ptr<IndexedBlock>
+    virtual std::shared_ptr<const IndexedBlock>
     getIndexedBlock(const std::string& name) const;
 
     virtual std::vector<std::string> getBlockNames() const
@@ -83,7 +83,7 @@ class EXPORT_MAEPARSER BufferedIndexedBlockMap : public IndexedBlockMapI
   public:
     virtual bool hasIndexedBlock(const std::string& name) const;
 
-    virtual std::shared_ptr<IndexedBlock>
+    virtual std::shared_ptr<const IndexedBlock>
     getIndexedBlock(const std::string& name) const;
 
     virtual std::vector<std::string> getBlockNames() const
@@ -150,7 +150,7 @@ class EXPORT_MAEPARSER Block
         return hasIndexedBlockData() && m_indexed_block_map->hasIndexedBlock(name);
     }
 
-    std::shared_ptr<IndexedBlock> getIndexedBlock(const std::string& name);
+    std::shared_ptr<const IndexedBlock> getIndexedBlock(const std::string& name);
 
     void addBlock(std::shared_ptr<Block> b) { m_sub_block[b->getName()] = b; }
 

--- a/Reader.cpp
+++ b/Reader.cpp
@@ -22,7 +22,7 @@ Reader::Reader(std::string fname, size_t buffer_size)
     } else if (ends_with(fname, ".maegz") || ends_with(fname, ".mae.gz")) {
         m_pregzip_stream = stream; // Store it since maeparser won't
         m_gzip_stream = std::make_shared<
-            boost::iostreams::filtering_streambuf<boost::iostreams::input>>();
+            boost::iostreams::filtering_istreambuf>();
         m_gzip_stream->push(boost::iostreams::gzip_decompressor());
         m_gzip_stream->push(*stream);
         auto decompressed_stream =

--- a/Reader.hpp
+++ b/Reader.hpp
@@ -19,9 +19,7 @@ class EXPORT_MAEPARSER Reader
   private:
     std::shared_ptr<MaeParser> m_mae_parser;
     std::shared_ptr<std::ifstream> m_pregzip_stream;
-    std::shared_ptr<
-        boost::iostreams::filtering_streambuf<boost::iostreams::input>>
-        m_gzip_stream;
+    std::shared_ptr<boost::iostreams::filtering_istreambuf> m_gzip_stream;
 
   public:
     Reader(FILE* file, size_t buffer_size = BufferLoader::DEFAULT_SIZE)

--- a/Writer.cpp
+++ b/Writer.cpp
@@ -1,0 +1,53 @@
+#include "Writer.hpp"
+
+#include <fstream>
+#include <iostream>
+#include <boost/algorithm/string/predicate.hpp>
+
+#include "MaeBlock.hpp"
+
+using namespace std;
+using boost::algorithm::ends_with;
+
+namespace schrodinger
+{
+namespace mae
+{
+
+Writer::Writer(std::shared_ptr<ostream> stream)
+{
+    m_out = stream;
+    write_opening_block();
+}
+
+Writer::Writer(std::string fname)
+{
+    auto pregzip_stream = new ofstream();
+    pregzip_stream->open(fname, std::ios_base::out | std::ios_base::binary);
+
+    if (ends_with(fname, ".maegz") || ends_with(fname, ".mae.gz")) {
+        m_gzip_stream = std::make_shared<boost::iostreams::filtering_ostreambuf>();
+        m_gzip_compressor = make_shared<boost::iostreams::gzip_compressor>();
+        m_gzip_stream->push(*m_gzip_compressor);
+        m_gzip_stream->push(*pregzip_stream);
+        m_out = std::make_shared<std::ostream>(m_gzip_stream.get());
+    } else {
+        m_out.reset(dynamic_cast<ostream*>(pregzip_stream));
+    }
+    write_opening_block();
+}
+
+void Writer::write(const std::shared_ptr<Block>& block)
+{
+    block->write(*m_out);
+}
+
+void Writer::write_opening_block()
+{
+    shared_ptr<Block> b = make_shared<Block>("");
+    b->setStringProperty("s_m_m2io_version", "2.0.0");
+    write(b);
+}
+
+} // namespace mae
+} // namespace schrodinger

--- a/Writer.hpp
+++ b/Writer.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <boost/iostreams/filter/gzip.hpp>
+#include <boost/iostreams/filtering_streambuf.hpp>
+#include <cstdio>
+#include <string>
+
+#include "MaeParserConfig.hpp"
+
+
+namespace schrodinger
+{
+namespace mae
+{
+
+class Block;
+
+class EXPORT_MAEPARSER Writer
+{
+  private:
+    std::shared_ptr<boost::iostreams::filtering_ostreambuf> m_gzip_stream;
+    std::shared_ptr<boost::iostreams::gzip_compressor> m_gzip_compressor;
+    std::shared_ptr<std::ostream> m_out;
+
+    void write_opening_block();
+
+  public:
+    Writer(std::shared_ptr<std::ostream> stream);
+    Writer(std::string fname);
+
+    void write(const std::shared_ptr<Block>& block);
+};
+
+} // namespace mae
+} // namespace schrodinger

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 include_directories(..)
 
 add_executable(unittest
-    MainTestSuite.cpp BufferTest.cpp MaeBlockTest.cpp MaeParserTest.cpp ReaderTest.cpp UsageDemo.cpp)
+    MainTestSuite.cpp BufferTest.cpp MaeBlockTest.cpp MaeParserTest.cpp ReaderTest.cpp WriterTest.cpp UsageDemo.cpp)
 
 target_link_libraries(unittest maeparser Boost::unit_test_framework)
 

--- a/test/MaeBlockTest.cpp
+++ b/test/MaeBlockTest.cpp
@@ -198,4 +198,96 @@ BOOST_AUTO_TEST_CASE(maeIndexedBlockString)
     }
 }
 
+std::shared_ptr<mae::IndexedBlock> getExampleIndexedBlock()
+{
+    using namespace mae;
+    auto ib = std::make_shared<IndexedBlock>("m_atom");
+
+    // Set up a bool property
+    std::vector<BoolProperty> dv;
+    boost::dynamic_bitset<>* bs = new boost::dynamic_bitset<>(3);
+    bs->set(1);
+
+    dv.push_back(true);
+    dv.push_back(false);
+    dv.push_back(true);
+    auto ibps = std::shared_ptr<IndexedBoolProperty>(
+            new IndexedBoolProperty(dv, bs));
+    ib->setBoolProperty("b_m_bool", ibps);
+
+    // Set up a real property
+    std::vector<double> rv = {0.1, 42};
+    boost::dynamic_bitset<>* rbs = new boost::dynamic_bitset<>(3);
+    rbs->set(2);
+
+    auto irps = std::shared_ptr<IndexedRealProperty>(
+            new IndexedRealProperty(rv, rbs));
+    ib->setRealProperty("r_m_reals", irps);
+
+    return ib;
+}
+
+BOOST_AUTO_TEST_CASE(toStringProperties)
+{
+    const std::string rval = \
+R"(dummy {
+  b_m_bool
+  r_m_real
+  i_m_int
+  s_m_string
+  :::
+  0
+  1.000000
+  42
+  "mae\"parser"
+  m_atom[3] {
+    # First column is Index #
+    b_m_bool
+    r_m_reals
+    :::
+    1 1 0.100000
+    2 <> 42.000000
+    3 1 <>
+    :::
+  }
+}
+
+)";
+    mae::Block b("dummy");
+    b.setRealProperty("r_m_real", 1.0);
+    b.setBoolProperty("b_m_bool", false);
+    b.setIntProperty("i_m_int", 42);
+    b.setStringProperty("s_m_string", "mae\"parser");
+
+    auto ib = getExampleIndexedBlock();
+
+    auto ibm = std::make_shared<mae::IndexedBlockMap>();
+    ibm->addIndexedBlock(ib->getName(), ib);
+    b.setIndexedBlockMap(ibm);
+
+    BOOST_REQUIRE_EQUAL(b.toString(), rval);
+}
+
+BOOST_AUTO_TEST_CASE(toStringIndexedProperties)
+{
+    using namespace mae;
+    const std::string rval = \
+R"(m_atom[3] {
+  # First column is Index #
+  b_m_bool
+  r_m_reals
+  :::
+  1 1 0.100000
+  2 <> 42.000000
+  3 1 <>
+  :::
+}
+)";
+
+    auto ib = getExampleIndexedBlock();
+
+    BOOST_REQUIRE_EQUAL(ib->toString(), rval);
+}
+
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/MaeBlockTest.cpp
+++ b/test/MaeBlockTest.cpp
@@ -204,15 +204,11 @@ std::shared_ptr<mae::IndexedBlock> getExampleIndexedBlock()
     auto ib = std::make_shared<IndexedBlock>("m_atom");
 
     // Set up a bool property
-    std::vector<BoolProperty> dv;
+    std::vector<BoolProperty> dv = {true, false, true};
     boost::dynamic_bitset<>* bs = new boost::dynamic_bitset<>(3);
     bs->set(1);
 
-    dv.push_back(true);
-    dv.push_back(false);
-    dv.push_back(true);
-    auto ibps = std::shared_ptr<IndexedBoolProperty>(
-            new IndexedBoolProperty(dv, bs));
+    auto ibps = std::make_shared<IndexedBoolProperty>(dv, bs);
     ib->setBoolProperty("b_m_bool", ibps);
 
     // Set up a real property

--- a/test/ReaderTest.cpp
+++ b/test/ReaderTest.cpp
@@ -206,7 +206,7 @@ BOOST_AUTO_TEST_CASE(NestedIndexedBlock)
 
     auto b = r.next(CT_BLOCK);
     BOOST_REQUIRE(b);
-    std::shared_ptr<IndexedBlock> ibn = b->getIndexedBlock("m_nested");
+    auto ibn = b->getIndexedBlock("m_nested");
     auto prop = ibn->getStringProperty("s_m_prop");
     BOOST_REQUIRE_EQUAL((*prop)[0], "1.1.0");
     BOOST_REQUIRE_EQUAL((*prop)[1], "1.1.0");
@@ -221,8 +221,8 @@ BOOST_AUTO_TEST_CASE(BufferedReader)
     size_t count = 0;
     std::shared_ptr<Block> b;
     while ((b = r.next(CT_BLOCK)) != nullptr) {
-        std::shared_ptr<IndexedBlock> iba = b->getIndexedBlock(ATOM_BLOCK);
-        std::shared_ptr<IndexedBlock> ibb = b->getIndexedBlock(BOND_BLOCK);
+        auto iba = b->getIndexedBlock(ATOM_BLOCK);
+        auto ibb = b->getIndexedBlock(BOND_BLOCK);
         count++;
     }
     BOOST_REQUIRE_EQUAL(count, 3u);
@@ -237,8 +237,8 @@ BOOST_AUTO_TEST_CASE(BufferedFileReader)
     size_t count = 0;
     std::shared_ptr<Block> b;
     while ((b = r.next(CT_BLOCK)) != nullptr) {
-        std::shared_ptr<IndexedBlock> iba = b->getIndexedBlock(ATOM_BLOCK);
-        std::shared_ptr<IndexedBlock> ibb = b->getIndexedBlock(BOND_BLOCK);
+        auto iba = b->getIndexedBlock(ATOM_BLOCK);
+        auto ibb = b->getIndexedBlock(BOND_BLOCK);
         count++;
     }
     fclose(f);
@@ -284,8 +284,8 @@ BOOST_AUTO_TEST_CASE(DirectReader)
     size_t count = 0;
     std::shared_ptr<Block> b;
     while ((b = r.next(CT_BLOCK)) != nullptr) {
-        std::shared_ptr<IndexedBlock> iba = b->getIndexedBlock(ATOM_BLOCK);
-        std::shared_ptr<IndexedBlock> ibb = b->getIndexedBlock(BOND_BLOCK);
+        auto iba = b->getIndexedBlock(ATOM_BLOCK);
+        auto ibb = b->getIndexedBlock(BOND_BLOCK);
         count++;
     }
     fclose(f);

--- a/test/ReaderTest.cpp
+++ b/test/ReaderTest.cpp
@@ -290,6 +290,7 @@ BOOST_AUTO_TEST_CASE(DirectReader)
     }
     fclose(f);
     BOOST_REQUIRE_EQUAL(count, 3u);
+
 }
 
 BOOST_AUTO_TEST_CASE(QuotedStringTest)

--- a/test/WriterTest.cpp
+++ b/test/WriterTest.cpp
@@ -1,0 +1,60 @@
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+
+#include "MaeBlock.hpp"
+#include "Reader.hpp"
+#include "Writer.hpp"
+#include "MaeConstants.hpp"
+
+#define BOOST_TEST_DYN_LINK
+#include <boost/test/unit_test.hpp>
+
+using namespace schrodinger::mae;
+using std::shared_ptr;
+
+BOOST_AUTO_TEST_SUITE(WriterSuite)
+
+BOOST_AUTO_TEST_CASE(Writer0)
+{
+    Reader r("test.mae");
+    auto w = new Writer("test_write.mae");
+    std::vector<std::shared_ptr<Block> > input;
+
+    std::shared_ptr<Block> b;
+    while ((b = r.next(CT_BLOCK)) != nullptr) {
+        input.push_back(b);
+        w->write(b);
+    }
+    delete w;
+
+    Reader output_r("test_write.mae");
+    int input_num = 0;
+    while ((b = output_r.next(CT_BLOCK)) != nullptr) {
+        BOOST_CHECK(*b == *(input[input_num++]));
+    }
+
+}
+
+BOOST_AUTO_TEST_CASE(Writer1)
+{
+    Reader r("test.mae");
+    auto w = new Writer("test_write.maegz");
+    std::vector<std::shared_ptr<Block> > input;
+
+    std::shared_ptr<Block> b;
+    while ((b = r.next(CT_BLOCK)) != nullptr) {
+        input.push_back(b);
+        w->write(b);
+    }
+    delete w;
+
+    Reader output_r("test_write.maegz");
+    int input_num = 0;
+    while ((b = output_r.next(CT_BLOCK)) != nullptr) {
+        BOOST_CHECK(*b == *(input[input_num++]));
+    }
+
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/WriterTest.cpp
+++ b/test/WriterTest.cpp
@@ -18,7 +18,7 @@ BOOST_AUTO_TEST_SUITE(WriterSuite)
 BOOST_AUTO_TEST_CASE(Writer0)
 {
     Reader r("test.mae");
-    auto w = new Writer("test_write.mae");
+    auto w = std::make_shared<Writer>("test_write.mae");
     std::vector<std::shared_ptr<Block> > input;
 
     std::shared_ptr<Block> b;
@@ -26,7 +26,7 @@ BOOST_AUTO_TEST_CASE(Writer0)
         input.push_back(b);
         w->write(b);
     }
-    delete w;
+    w.reset();
 
     Reader output_r("test_write.mae");
     int input_num = 0;
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE(Writer0)
 BOOST_AUTO_TEST_CASE(Writer1)
 {
     Reader r("test.mae");
-    auto w = new Writer("test_write.maegz");
+    auto w = std::make_shared<Writer>("test_write.maegz");
     std::vector<std::shared_ptr<Block> > input;
 
     std::shared_ptr<Block> b;
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(Writer1)
         input.push_back(b);
         w->write(b);
     }
-    delete w;
+    w.reset();
 
     Reader output_r("test_write.maegz");
     int input_num = 0;


### PR DESCRIPTION
Probably half of the code here is also to introduce equality operators for Block's, this makes round trip testing much easier.

Note:  This writer is *not* built/intended for high performance, just ease of being written and readability.  The main use case here (other toolkits using this to write Maestro files) is not one where super high performance is necessary.  Going forward we are working out the details of a new superior format, we'll be putting performance focus into that place.

fixes #18 
