### PR TITLE
Restore "ifstream&" interface

### DIFF
--- a/MaeParser.hpp
+++ b/MaeParser.hpp
@@ -259,7 +259,6 @@ class EXPORT_MAEPARSER MaeParser
 {
   protected:
     Buffer m_buffer;
-    std::shared_ptr<std::istream> m_stream;
 
     virtual IndexedBlockParser* getIndexedBlockParser()
     {
@@ -267,9 +266,9 @@ class EXPORT_MAEPARSER MaeParser
     }
 
   public:
-    explicit MaeParser(std::shared_ptr<std::istream> stream,
+    explicit MaeParser(std::istream& stream,
                        size_t buffer_size = BufferLoader::DEFAULT_SIZE)
-        : m_stream(stream), m_buffer(*stream, buffer_size)
+        : m_buffer(stream, buffer_size)
     {
         m_buffer.load();
     }
@@ -330,7 +329,7 @@ class EXPORT_MAEPARSER MaeParser
 class EXPORT_MAEPARSER DirectMaeParser : public MaeParser
 {
   public:
-    explicit DirectMaeParser(std::shared_ptr<std::istream> stream,
+    explicit DirectMaeParser(std::istream& stream,
                              size_t buffer_size = BufferLoader::DEFAULT_SIZE)
         : MaeParser(stream, buffer_size)
     {

--- a/Reader.cpp
+++ b/Reader.cpp
@@ -15,20 +15,15 @@ namespace mae
 
 Reader::Reader(std::string fname, size_t buffer_size)
 {
-    auto stream = std::make_shared<std::ifstream>(
-        fname, std::ios_base::in | std::ios_base::binary);
+    std::unique_ptr<std::ifstream> stream(new std::ifstream( fname, std::ios_base::in | std::ios_base::binary));
     if (ends_with(fname, ".mae")) {
-        m_mae_parser.reset(new MaeParser(stream, buffer_size));
+        m_mae_parser.reset(new MaeParser(*stream, buffer_size));
     } else if (ends_with(fname, ".maegz") || ends_with(fname, ".mae.gz")) {
-        m_pregzip_stream = stream; // Store it since maeparser won't
-        m_gzip_stream = std::make_shared<
-            boost::iostreams::filtering_streambuf<boost::iostreams::input>>();
-        m_gzip_stream->push(boost::iostreams::gzip_decompressor());
-        m_gzip_stream->push(*stream);
-        auto decompressed_stream =
-            std::make_shared<std::istream>(m_gzip_stream.get());
-        m_mae_parser =
-            std::make_shared<MaeParser>(decompressed_stream, buffer_size);
+        m_gzip_stream_filter.reset(new boost::iostreams::filtering_streambuf<boost::iostreams::input>());
+        m_gzip_stream_filter->push(boost::iostreams::gzip_decompressor());
+        m_gzip_stream_filter->push(*stream);
+        m_stream.reset(new std::istream(m_gzip_stream_filter.get()));
+        m_mae_parser.reset(new MaeParser(*m_stream, buffer_size));
     }
 }
 

--- a/Reader.hpp
+++ b/Reader.hpp
@@ -17,11 +17,11 @@ namespace mae
 class EXPORT_MAEPARSER Reader
 {
   private:
-    std::shared_ptr<MaeParser> m_mae_parser;
-    std::shared_ptr<std::ifstream> m_pregzip_stream;
-    std::shared_ptr<
+    std::shared_ptr<MaeParser> m_mae_parser = nullptr;
+    std::unique_ptr<std::istream> m_stream = nullptr;
+    std::unique_ptr<
         boost::iostreams::filtering_streambuf<boost::iostreams::input>>
-        m_gzip_stream;
+        m_gzip_stream_filter = nullptr;
 
   public:
     Reader(FILE* file, size_t buffer_size = BufferLoader::DEFAULT_SIZE)
@@ -29,7 +29,7 @@ class EXPORT_MAEPARSER Reader
         m_mae_parser.reset(new MaeParser(file, buffer_size));
     }
 
-    Reader(std::shared_ptr<std::istream> stream,
+    Reader(std::istream &stream,
            size_t buffer_size = BufferLoader::DEFAULT_SIZE)
     {
         m_mae_parser.reset(new MaeParser(stream, buffer_size));

--- a/test/MaeParserTest.cpp
+++ b/test/MaeParserTest.cpp
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE(OuterBlockBeginErrors)
 BOOST_AUTO_TEST_CASE(BlockBeginning)
 {
     {
-        auto ss = std::make_shared<std::stringstream>("m_something {");
+        auto ss = std::stringstream("m_something {");
         int indexed = 0;
         MaeParser mp(ss);
         std::string name = mp.blockBeginning(&indexed);
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(BlockBeginning)
         BOOST_REQUIRE_EQUAL(indexed, 0);
     }
     {
-        auto ss = std::make_shared<std::stringstream>("mmmm_block{");
+        auto ss = std::stringstream("mmmm_block{");
         int indexed = 0;
         MaeParser mp(ss);
         std::string name = mp.blockBeginning(&indexed);
@@ -140,7 +140,7 @@ BOOST_AUTO_TEST_CASE(BlockBeginning)
         BOOST_REQUIRE_EQUAL(indexed, 0);
     }
     {
-        auto ss = std::make_shared<std::stringstream>("m_whatev[23]{");
+        auto ss = std::stringstream("m_whatev[23]{");
         int indexed = 0;
         MaeParser mp(ss);
         std::string name = mp.blockBeginning(&indexed);
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_CASE(BlockBeginningErrors)
 {
     {
         try {
-            auto ss = std::make_shared<std::stringstream>("");
+            auto ss = std::stringstream("");
             int indexed = 0;
             MaeParser mp(ss);
             mp.blockBeginning(&indexed);
@@ -167,7 +167,7 @@ BOOST_AUTO_TEST_CASE(BlockBeginningErrors)
     }
     {
         try {
-            auto ss = std::make_shared<std::stringstream>("m_block[integer]");
+            auto ss = std::stringstream("m_block[integer]");
             int indexed = 0;
             MaeParser mp(ss);
             mp.blockBeginning(&indexed);
@@ -180,7 +180,7 @@ BOOST_AUTO_TEST_CASE(BlockBeginningErrors)
     }
     {
         try {
-            auto ss = std::make_shared<std::stringstream>("m_block[33  ");
+            auto ss = std::stringstream("m_block[33  ");
             int indexed = 0;
             MaeParser mp(ss);
             mp.blockBeginning(&indexed);
@@ -193,8 +193,7 @@ BOOST_AUTO_TEST_CASE(BlockBeginningErrors)
     }
     {
         try {
-            auto ss =
-                std::make_shared<std::stringstream>("m_block[33]  s_m_foo");
+            auto ss = std::stringstream("m_block[33]  s_m_foo");
             int indexed = 0;
             MaeParser mp(ss);
             mp.blockBeginning(&indexed);
@@ -207,7 +206,7 @@ BOOST_AUTO_TEST_CASE(BlockBeginningErrors)
     }
     {
         try {
-            auto ss = std::make_shared<std::stringstream>("'bad_block");
+            auto ss = std::stringstream("'bad_block");
             int indexed = 0;
             MaeParser mp(ss);
             mp.blockBeginning(&indexed);
@@ -221,7 +220,7 @@ BOOST_AUTO_TEST_CASE(BlockBeginningErrors)
     }
     {
         try {
-            auto ss = std::make_shared<std::stringstream>("mmmm_ ");
+            auto ss = std::stringstream("mmmm_ ");
             int indexed = 0;
             MaeParser mp(ss);
             mp.blockBeginning(&indexed);
@@ -239,23 +238,21 @@ BOOST_AUTO_TEST_CASE(BlockBody)
 {
     double tolerance = std::numeric_limits<double>::epsilon();
     {
-        auto ss =
-            std::make_shared<std::stringstream>("b_m_foo b_m_bar::: 1 0 }");
+        auto ss = std::stringstream("b_m_foo b_m_bar::: 1 0 }");
         MaeParser mp(ss);
         auto bl = mp.blockBody(CT_BLOCK);
         BOOST_REQUIRE(bl->getBoolProperty("b_m_foo"));
         BOOST_REQUIRE(!bl->getBoolProperty("b_m_bar"));
     }
     {
-        auto ss =
-            std::make_shared<std::stringstream>(" b_m_foo b_m_bar ::: 1 0 }");
+        auto ss = std::stringstream(" b_m_foo b_m_bar ::: 1 0 }");
         MaeParser mp(ss);
         auto bl = mp.blockBody(CT_BLOCK);
         BOOST_REQUIRE(bl->getBoolProperty("b_m_foo"));
         BOOST_REQUIRE(!bl->getBoolProperty("b_m_bar"));
     }
     {
-        auto ss = std::make_shared<std::stringstream>(
+        auto ss = std::stringstream(
             " b_m_foo b_m_bar s_m_foo r_m_foo i_m_foo ::: "
             " 1       0       svalue  3.1415  22 }");
         MaeParser mp(ss);
@@ -271,7 +268,7 @@ BOOST_AUTO_TEST_CASE(BlockBody)
 BOOST_AUTO_TEST_CASE(BlockBodyErrors)
 {
     {
-        auto ss = std::make_shared<std::stringstream>(
+        auto ss = std::stringstream(
             " b_m_foo\n s_m_foo\n r_m_foo\n i_m_foo\n :::\n"
             " 1\n svalue\n 3.1415\n 22\n ");
         MaeParser mp(ss);
@@ -288,25 +285,25 @@ BOOST_AUTO_TEST_CASE(BlockBodyErrors)
 BOOST_AUTO_TEST_CASE(Property)
 {
     {
-        auto ss = std::make_shared<std::stringstream>("b_m_foo ");
+        auto ss = std::stringstream("b_m_foo ");
         MaeParser mp(ss);
         auto p = mp.property();
         BOOST_REQUIRE(*p == "b_m_foo");
     }
     {
-        auto ss = std::make_shared<std::stringstream>("r_m_bar ");
+        auto ss = std::stringstream("r_m_bar ");
         MaeParser mp(ss);
         auto p = mp.property();
         BOOST_REQUIRE(*p == "r_m_bar");
     }
     {
-        auto ss = std::make_shared<std::stringstream>("b_st_1_2_3_4_R_5 ");
+        auto ss = std::stringstream("b_st_1_2_3_4_R_5 ");
         MaeParser mp(ss);
         auto p = mp.property();
         BOOST_REQUIRE(*p == "b_st_1_2_3_4_R_5");
     }
     {
-        auto ss = std::make_shared<std::stringstream>("s_author_name ");
+        auto ss = std::stringstream("s_author_name ");
         MaeParser mp(ss);
         auto p = mp.property();
         BOOST_REQUIRE(*p == "s_author_name");
@@ -316,7 +313,7 @@ BOOST_AUTO_TEST_CASE(Property)
 BOOST_AUTO_TEST_CASE(PropertyValueSeparator)
 {
     {
-        auto ss = std::make_shared<std::stringstream>(":::");
+        auto ss = std::stringstream(":::");
         MaeParser mp(ss);
         auto p = mp.property();
         BOOST_REQUIRE(p == nullptr);
@@ -327,7 +324,7 @@ BOOST_AUTO_TEST_CASE(PropertyList)
 {
     {
         std::vector<std::string> properties;
-        auto ss = std::make_shared<std::stringstream>("b_m_foo s_j_bar :::");
+        auto ss = std::stringstream("b_m_foo s_j_bar :::");
         // Buffer size of 14 was chosen to reproduce a bug during development;
         // a buffer boundary in the name part of the key.
         MaeParser mp(ss, 14u);
@@ -345,7 +342,7 @@ BOOST_AUTO_TEST_CASE(PropertyList)
     }
     {
         std::vector<std::string> properties;
-        auto ss = std::make_shared<std::stringstream>("b_m_foo s_j_ :::");
+        auto ss = std::stringstream("b_m_foo s_j_ :::");
         MaeParser mp(ss);
         try {
             while (true) {
@@ -370,7 +367,7 @@ BOOST_AUTO_TEST_CASE(PropertyErrors)
 {
     {
         try {
-            auto ss = std::make_shared<std::stringstream>("bo_m_foo ");
+            auto ss = std::stringstream("bo_m_foo ");
             MaeParser mp(ss);
             mp.property();
             BOOST_FAIL("Expected an exception.");
@@ -383,7 +380,7 @@ BOOST_AUTO_TEST_CASE(PropertyErrors)
     }
     {
         try {
-            auto ss = std::make_shared<std::stringstream>("x_m_foo ");
+            auto ss = std::stringstream("x_m_foo ");
             MaeParser mp(ss);
             mp.property();
             BOOST_FAIL("Expected an exception.");
@@ -396,7 +393,7 @@ BOOST_AUTO_TEST_CASE(PropertyErrors)
     }
     {
         try {
-            auto ss = std::make_shared<std::stringstream>("s_m_");
+            auto ss = std::stringstream("s_m_");
             MaeParser mp(ss);
             mp.property();
             BOOST_FAIL("Expected an exception.");
@@ -409,7 +406,7 @@ BOOST_AUTO_TEST_CASE(PropertyErrors)
     }
     {
         try {
-            auto ss = std::make_shared<std::stringstream>("s_m_ ");
+            auto ss = std::stringstream("s_m_ ");
             MaeParser mp(ss);
             mp.property();
             BOOST_FAIL("Expected an exception.");

--- a/test/ReaderTest.cpp
+++ b/test/ReaderTest.cpp
@@ -16,8 +16,8 @@ BOOST_AUTO_TEST_SUITE(ReaderSuite)
 
 BOOST_AUTO_TEST_CASE(Reader0)
 {
-    auto ss = std::make_shared<std::stringstream>();
-    *ss << "\n"
+    auto ss = std::stringstream();
+    ss << "\n"
         << "{"
            "\n"
         << "  s_m_m2io_version"
@@ -38,8 +38,8 @@ BOOST_AUTO_TEST_CASE(Reader0)
 
 BOOST_AUTO_TEST_CASE(NamedBlock0)
 {
-    auto ss = std::make_shared<std::stringstream>();
-    *ss << "\n"
+    auto ss = std::stringstream();
+    ss << "\n"
         << "\n"
         << "f_m_ct {"
            "\n"
@@ -61,8 +61,8 @@ BOOST_AUTO_TEST_CASE(NamedBlock0)
 
 BOOST_AUTO_TEST_CASE(NamedBlock1)
 {
-    auto ss = std::make_shared<std::stringstream>();
-    *ss << "{"
+    auto ss = std::stringstream();
+    ss << "{"
            "\n"
         << "  s_m_m2io_version"
            "\n"
@@ -96,8 +96,8 @@ BOOST_AUTO_TEST_CASE(NamedBlock1)
 
 BOOST_AUTO_TEST_CASE(NestedBlock)
 {
-    auto ss = std::make_shared<std::stringstream>();
-    *ss << "{"
+    auto ss = std::stringstream();
+    ss << "{"
            "\n"
         << "  s_m_m2io_version"
            "\n"
@@ -141,8 +141,8 @@ BOOST_AUTO_TEST_CASE(NestedBlock)
 
 BOOST_AUTO_TEST_CASE(NestedIndexedBlock)
 {
-    auto ss = std::make_shared<std::stringstream>();
-    *ss << "{"
+    auto ss = std::stringstream();
+    ss << "{"
            "\n" // 1
         << "  s_m_m2io_version"
            "\n" // 2
@@ -214,7 +214,7 @@ BOOST_AUTO_TEST_CASE(NestedIndexedBlock)
 
 BOOST_AUTO_TEST_CASE(BufferedReader)
 {
-    auto ss = std::make_shared<std::ifstream>("test.mae");
+    auto ss = std::ifstream("test.mae");
 
     Reader r(ss);
 
@@ -247,7 +247,7 @@ BOOST_AUTO_TEST_CASE(BufferedFileReader)
 
 BOOST_AUTO_TEST_CASE(TextReader)
 {
-    auto ss = std::make_shared<std::ifstream>("test.mae");
+    auto ss = std::ifstream("test.mae");
 
     Reader r(ss);
 


### PR DESCRIPTION
With fix for #20, the interface for some classes (`Reader`, `MaeParser`, etc) changed from an `istream&` to a `shared::ptr<istream>`, which breaks "drop in" compatibility with previous releases. This patch brings back the `istream&` interface.