### PR TITLE
Enable test memcheck & relocatable tests.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,10 +38,11 @@ target_compile_definitions(maeparser PRIVATE IN_MAEPARSER)
 
 set_property(TARGET maeparser PROPERTY CXX_VISIBILITY_PRESET "hidden")
 
-enable_testing()
+# Enable CTest
+include(CTest)
 add_subdirectory(test)
 
-add_test(NAME unittest COMMAND ${CMAKE_BINARY_DIR}/test/unittest
+add_test(NAME unittest COMMAND $<TARGET_FILE:unittest>
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test)
 
 install(FILES Buffer.hpp MaeBlock.hpp  MaeParserConfig.hpp  MaeParser.hpp  Reader.hpp MaeConstants.hpp


### PR DESCRIPTION
This patch enables the usage of `ctest -T memcheck` to run the `unittest` executable under valgrind, to check for memory errors.

Also, it allows `ctest` to find `unittest` under the build directory tree when `maeparser` is compiled as a subproject (i.e. under CoordGen): prior to this patch, `unittest` had to be run manually; after the patch, running `ctest` from the root of the build directory of the "main" project should know about and run `unittest` too.