### PR TITLE
Apply clang-format

### DIFF
--- a/MaeBlock.cpp
+++ b/MaeBlock.cpp
@@ -1,7 +1,6 @@
 #include "MaeBlock.hpp"
 #include <cmath>
 
-
 #include "MaeParser.hpp"
 
 using namespace std;
@@ -13,57 +12,56 @@ namespace mae
 
 static const double tolerance = 0.00001; // Tolerance to match string cutoff
 
-
 // Wrap to-string to allow it to take strings and be a no-op
-template <typename T>
-static string local_to_string(T val)
+template <typename T> static string local_to_string(T val)
 {
     return to_string(val);
 }
 
 static string local_to_string(string val)
 {
-    if(val.length() == 0) return R"("")";
+    if (val.length() == 0)
+        return R"("")";
     // Create new string big enough to escape every character and add quotes
     int pos_in_old = 0;
     bool escaped_char = false;
-    for(; pos_in_old<val.length(); ++pos_in_old) {
+    for (; pos_in_old < val.length(); ++pos_in_old) {
         const char& c = val[pos_in_old];
-        if(c == '"' || c == '\\' || c == ' ') {
+        if (c == '"' || c == '\\' || c == ' ') {
             escaped_char = true;
             break;
         }
     }
-    if(!escaped_char) return val;
+    if (!escaped_char)
+        return val;
 
     int pos_in_new = 1;
-    string new_string(val.length()*2 + 2, '\"');
-    for(pos_in_old = 0; pos_in_old<val.length(); ++pos_in_old)
-    {
+    string new_string(val.length() * 2 + 2, '\"');
+    for (pos_in_old = 0; pos_in_old < val.length(); ++pos_in_old) {
         const char& c = val[pos_in_old];
-        if(c == '"' || c == '\\') {
+        if (c == '"' || c == '\\') {
             new_string[pos_in_new++] = '\\';
         }
         new_string[pos_in_new++] = val[pos_in_old];
     }
-    new_string.resize(pos_in_new+1);
+    new_string.resize(pos_in_new + 1);
     return new_string;
 }
 
 template <typename T>
-static void output_property_names(ostream& out,
-        const string& indentation, map<string, T> properties)
+static void output_property_names(ostream& out, const string& indentation,
+                                  map<string, T> properties)
 {
-    for(const auto& p : properties) {
+    for (const auto& p : properties) {
         out << indentation << p.first << "\n";
     }
 }
 
 template <typename T>
-static void output_property_values(ostream& out,
-        const string& indentation, map<string, T> properties)
+static void output_property_values(ostream& out, const string& indentation,
+                                   map<string, T> properties)
 {
-    for(const auto& p : properties) {
+    for (const auto& p : properties) {
         out << indentation << local_to_string(p.second) << "\n";
     }
 }
@@ -77,7 +75,7 @@ void Block::write(ostream& out, unsigned int current_indentation) const
 {
 
     string root_indentation = string(current_indentation, ' ');
-    string indentation = string(current_indentation+2, ' ');
+    string indentation = string(current_indentation + 2, ' ');
 
     out << root_indentation << getName() << " {\n";
 
@@ -86,7 +84,7 @@ void Block::write(ostream& out, unsigned int current_indentation) const
     output_property_names(out, indentation, m_imap);
     output_property_names(out, indentation, m_smap);
 
-    if(m_bmap.size() + m_rmap.size() + m_imap.size() + m_smap.size() > 0) {
+    if (m_bmap.size() + m_rmap.size() + m_imap.size() + m_smap.size() > 0) {
         out << indentation + ":::\n";
     }
 
@@ -95,19 +93,19 @@ void Block::write(ostream& out, unsigned int current_indentation) const
     output_property_values(out, indentation, m_imap);
     output_property_values(out, indentation, m_smap);
 
-    if(hasIndexedBlockData()) {
+    if (hasIndexedBlockData()) {
         const auto block_names = m_indexed_block_map->getBlockNames();
-        for(const auto& name : block_names) {
-            const auto& indexed_block = m_indexed_block_map->getIndexedBlock(name);
-            indexed_block->write(out, current_indentation+2);
+        for (const auto& name : block_names) {
+            const auto& indexed_block =
+                m_indexed_block_map->getIndexedBlock(name);
+            indexed_block->write(out, current_indentation + 2);
         }
     }
 
-    for(const auto& p : m_sub_block) {
+    for (const auto& p : m_sub_block) {
         const auto& sub_block = p.second;
-        sub_block->write(out, current_indentation+2);
+        sub_block->write(out, current_indentation + 2);
     }
-
 
     out << root_indentation << "}\n\n";
 
@@ -122,22 +120,25 @@ string Block::toString() const
     return stream.str();
 }
 
-
 shared_ptr<const IndexedBlock> Block::getIndexedBlock(const string& name)
 {
-    if(!hasIndexedBlockData()) {
+    if (!hasIndexedBlockData()) {
         throw out_of_range("Indexed block not found: " + name);
     }
-    return const_pointer_cast<const IndexedBlock>(m_indexed_block_map->getIndexedBlock(name));
+    return const_pointer_cast<const IndexedBlock>(
+        m_indexed_block_map->getIndexedBlock(name));
 }
 
 bool real_map_equal(const map<string, double>& rmap1,
-        const map<string, double>& rmap2)
+                    const map<string, double>& rmap2)
 {
-    if(rmap1.size() != rmap2.size()) return false;
-    for(const auto& p : rmap1) {
-        if(rmap2.count(p.first) != 1) return false;
-        if((float)abs(p.second - rmap2.at(p.first)) > tolerance) return false;
+    if (rmap1.size() != rmap2.size())
+        return false;
+    for (const auto& p : rmap1) {
+        if (rmap2.count(p.first) != 1)
+            return false;
+        if ((float) abs(p.second - rmap2.at(p.first)) > tolerance)
+            return false;
     }
 
     return true;
@@ -145,24 +146,31 @@ bool real_map_equal(const map<string, double>& rmap1,
 
 bool Block::operator==(const Block& rhs) const
 {
-    if(m_bmap != rhs.m_bmap) return false;
-    if(!real_map_equal(m_rmap, rhs.m_rmap)) return false;
-    if(m_imap != rhs.m_imap) return false;
-    if(m_smap != rhs.m_smap) return false;
-    if(m_sub_block != rhs.m_sub_block) return false;
-    if(!(*m_indexed_block_map == *(rhs.m_indexed_block_map))) return false;
+    if (m_bmap != rhs.m_bmap)
+        return false;
+    if (!real_map_equal(m_rmap, rhs.m_rmap))
+        return false;
+    if (m_imap != rhs.m_imap)
+        return false;
+    if (m_smap != rhs.m_smap)
+        return false;
+    if (m_sub_block != rhs.m_sub_block)
+        return false;
+    if (!(*m_indexed_block_map == *(rhs.m_indexed_block_map)))
+        return false;
     return true;
 }
-
 
 bool IndexedBlockMapI::operator==(const IndexedBlockMapI& rhs)
 {
     const auto& block_names = getBlockNames();
-    for(const auto& name : block_names) {
-        if(!rhs.hasIndexedBlock(name)) return false;
+    for (const auto& name : block_names) {
+        if (!rhs.hasIndexedBlock(name))
+            return false;
         const auto& block1 = rhs.getIndexedBlock(name);
         const auto& block2 = getIndexedBlock(name);
-        if(*block1 != *block2) return false;
+        if (*block1 != *block2)
+            return false;
     }
     return true;
 }
@@ -175,7 +183,7 @@ bool IndexedBlockMap::hasIndexedBlock(const string& name) const
 shared_ptr<const IndexedBlock>
 IndexedBlockMap::getIndexedBlock(const string& name) const
 {
-    map<string,shared_ptr<IndexedBlock>>::const_iterator block_iter =
+    map<string, shared_ptr<IndexedBlock>>::const_iterator block_iter =
         m_indexed_block.find(name);
     if (block_iter != m_indexed_block.end()) {
         return const_pointer_cast<const IndexedBlock>(block_iter->second);
@@ -214,15 +222,17 @@ BufferedIndexedBlockMap::getIndexedBlock(const string& name) const
 }
 
 template <>
-EXPORT_MAEPARSER void IndexedBlock::setProperty<BoolProperty>(
-    const string& name, shared_ptr<IndexedBoolProperty> value)
+EXPORT_MAEPARSER void
+IndexedBlock::setProperty<BoolProperty>(const string& name,
+                                        shared_ptr<IndexedBoolProperty> value)
 {
     set_indexed_property<IndexedBoolProperty>(m_bmap, name, value);
 }
 
 template <>
-EXPORT_MAEPARSER void IndexedBlock::setProperty<double>(
-    const string& name, shared_ptr<IndexedProperty<double>> value)
+EXPORT_MAEPARSER void
+IndexedBlock::setProperty<double>(const string& name,
+                                  shared_ptr<IndexedProperty<double>> value)
 {
     set_indexed_property<IndexedProperty<double>>(m_rmap, name, value);
 }
@@ -236,9 +246,9 @@ IndexedBlock::setProperty<int>(const string& name,
 }
 
 template <>
-EXPORT_MAEPARSER void IndexedBlock::setProperty<string>(
-    const string& name,
-    shared_ptr<IndexedProperty<string>> value)
+EXPORT_MAEPARSER void
+IndexedBlock::setProperty<string>(const string& name,
+                                  shared_ptr<IndexedProperty<string>> value)
 {
     set_indexed_property<IndexedProperty<string>>(m_smap, name, value);
 }
@@ -248,23 +258,26 @@ size_t IndexedBlock::size() const
     size_t count = 0;
     // To save memory, not all maps will have max index count for the block,
     // so we must find the max size of all maps in the block.
-    for(const auto& p : m_bmap) count = max(p.second->size(), count);
-    for(const auto& p : m_imap) count = max(p.second->size(), count);
-    for(const auto& p : m_rmap) count = max(p.second->size(), count);
-    for(const auto& p : m_smap) count = max(p.second->size(), count);
+    for (const auto& p : m_bmap)
+        count = max(p.second->size(), count);
+    for (const auto& p : m_imap)
+        count = max(p.second->size(), count);
+    for (const auto& p : m_rmap)
+        count = max(p.second->size(), count);
+    for (const auto& p : m_smap)
+        count = max(p.second->size(), count);
 
     return count;
 }
 
-
 template <typename T>
-static void output_indexed_property_values(ostream& out,
-        const string& indentation, map<string, T> properties,
-        unsigned int index)
+static void
+output_indexed_property_values(ostream& out, const string& indentation,
+                               map<string, T> properties, unsigned int index)
 {
-    for(const auto& p : properties) {
+    for (const auto& p : properties) {
         const auto& property = p.second;
-        if(property->isDefined(index)) {
+        if (property->isDefined(index)) {
             out << " " << local_to_string(property->at(index));
         } else {
             out << " <>";
@@ -275,12 +288,14 @@ static void output_indexed_property_values(ostream& out,
 void IndexedBlock::write(ostream& out, unsigned int current_indentation) const
 {
     string root_indentation = string(current_indentation, ' ');
-    string indentation = string(current_indentation+2, ' ');
-    const bool has_data = m_bmap.size() + m_rmap.size() + m_imap.size() + m_smap.size() > 0;
+    string indentation = string(current_indentation + 2, ' ');
+    const bool has_data =
+        m_bmap.size() + m_rmap.size() + m_imap.size() + m_smap.size() > 0;
 
-    out << root_indentation << getName() << "[" << to_string((int)size()) << "] {\n";
+    out << root_indentation << getName() << "[" << to_string((int) size())
+        << "] {\n";
 
-    if(has_data) {
+    if (has_data) {
         out << indentation + "# First column is Index #\n";
     }
 
@@ -289,12 +304,12 @@ void IndexedBlock::write(ostream& out, unsigned int current_indentation) const
     output_property_names(out, indentation, m_imap);
     output_property_names(out, indentation, m_smap);
 
-    if(has_data) {
+    if (has_data) {
         out << indentation + ":::\n";
     }
 
-    for(unsigned int i=0; i<size(); ++i) {
-        out << indentation << i+1;
+    for (unsigned int i = 0; i < size(); ++i) {
+        out << indentation << i + 1;
         output_indexed_property_values(out, indentation, m_bmap, i);
         output_indexed_property_values(out, indentation, m_rmap, i);
         output_indexed_property_values(out, indentation, m_imap, i);
@@ -302,7 +317,7 @@ void IndexedBlock::write(ostream& out, unsigned int current_indentation) const
         out << endl;
     }
 
-    if(has_data) {
+    if (has_data) {
         out << indentation + ":::\n";
     }
 
@@ -322,27 +337,32 @@ string IndexedBlock::toString() const
 template <typename T>
 bool IndexedProperty<T>::operator==(const IndexedProperty<T>& rhs) const
 {
-    if(m_is_null == nullptr || rhs.m_is_null == nullptr) {
-        if((m_is_null == nullptr) != (rhs.m_is_null == nullptr)) return false;
-    } else if(*m_is_null != *(rhs.m_is_null)) {
+    if (m_is_null == nullptr || rhs.m_is_null == nullptr) {
+        if ((m_is_null == nullptr) != (rhs.m_is_null == nullptr))
+            return false;
+    } else if (*m_is_null != *(rhs.m_is_null)) {
         return false;
     }
-    if(m_data != rhs.m_data) return false;
+    if (m_data != rhs.m_data)
+        return false;
     return true;
 }
-
 
 // For doubles we need to implement our own comparator for the vectors to
 // take precision into account
 template <>
-bool IndexedProperty<double>::operator==(const IndexedProperty<double>& rhs) const
+bool IndexedProperty<double>::
+operator==(const IndexedProperty<double>& rhs) const
 {
-    if(m_is_null == nullptr || rhs.m_is_null == nullptr) {
-        if((m_is_null == nullptr) != (rhs.m_is_null == nullptr)) return false;
-    } else if(*m_is_null != *(rhs.m_is_null)) return false;
+    if (m_is_null == nullptr || rhs.m_is_null == nullptr) {
+        if ((m_is_null == nullptr) != (rhs.m_is_null == nullptr))
+            return false;
+    } else if (*m_is_null != *(rhs.m_is_null))
+        return false;
 
-    for(int i=0; i<m_data.size(); ++i)
-        if((float)abs(m_data[i] - rhs.m_data[i]) > tolerance) return false;
+    for (int i = 0; i < m_data.size(); ++i)
+        if ((float) abs(m_data[i] - rhs.m_data[i]) > tolerance)
+            return false;
 
     return true;
 }
@@ -350,21 +370,28 @@ bool IndexedProperty<double>::operator==(const IndexedProperty<double>& rhs) con
 template <typename T>
 static bool maps_indexed_props_equal(const T& lmap, const T& rmap)
 {
-    if(rmap.size() != lmap.size()) return false;
-    auto diff = std::mismatch(lmap.begin(), lmap.end(), rmap.begin(),
-            [](decltype(*begin(lmap)) l, decltype(*begin(lmap)) r)
-            {return l.first == r.first && *(l.second) == *(r.second);});
-    if (diff.first != lmap.end()) return false;
+    if (rmap.size() != lmap.size())
+        return false;
+    auto diff = std::mismatch(
+        lmap.begin(), lmap.end(), rmap.begin(),
+        [](decltype(*begin(lmap)) l, decltype(*begin(lmap)) r) {
+            return l.first == r.first && *(l.second) == *(r.second);
+        });
+    if (diff.first != lmap.end())
+        return false;
     return true;
 }
 
-
 bool IndexedBlock::operator==(const IndexedBlock& rhs) const
 {
-    if(!maps_indexed_props_equal(m_bmap, rhs.m_bmap)) return false;
-    if(!maps_indexed_props_equal(m_imap, rhs.m_imap)) return false;
-    if(!maps_indexed_props_equal(m_rmap, rhs.m_rmap)) return false;
-    if(!maps_indexed_props_equal(m_smap, rhs.m_smap)) return false;
+    if (!maps_indexed_props_equal(m_bmap, rhs.m_bmap))
+        return false;
+    if (!maps_indexed_props_equal(m_imap, rhs.m_imap))
+        return false;
+    if (!maps_indexed_props_equal(m_rmap, rhs.m_rmap))
+        return false;
+    if (!maps_indexed_props_equal(m_smap, rhs.m_smap))
+        return false;
 
     return true;
 }

--- a/MaeBlock.hpp
+++ b/MaeBlock.hpp
@@ -56,7 +56,7 @@ class EXPORT_MAEPARSER IndexedBlockMap : public IndexedBlockMapI
     virtual std::vector<std::string> getBlockNames() const
     {
         std::vector<std::string> rval;
-        for(const auto& p : m_indexed_block) {
+        for (const auto& p : m_indexed_block) {
             rval.push_back(p.first);
         }
 
@@ -71,7 +71,6 @@ class EXPORT_MAEPARSER IndexedBlockMap : public IndexedBlockMapI
     {
         m_indexed_block[name] = indexed_block;
     }
-
 };
 
 class EXPORT_MAEPARSER BufferedIndexedBlockMap : public IndexedBlockMapI
@@ -89,7 +88,7 @@ class EXPORT_MAEPARSER BufferedIndexedBlockMap : public IndexedBlockMapI
     virtual std::vector<std::string> getBlockNames() const
     {
         std::vector<std::string> rval;
-        for(const auto& p : m_indexed_buffer) {
+        for (const auto& p : m_indexed_buffer) {
             rval.push_back(p.first);
         }
 
@@ -142,15 +141,15 @@ class EXPORT_MAEPARSER Block
         m_indexed_block_map = indexed_block_map;
     }
 
-    bool hasIndexedBlockData() const {
-        return m_indexed_block_map != nullptr;
-    }
+    bool hasIndexedBlockData() const { return m_indexed_block_map != nullptr; }
     bool hasIndexedBlock(const std::string& name)
     {
-        return hasIndexedBlockData() && m_indexed_block_map->hasIndexedBlock(name);
+        return hasIndexedBlockData() &&
+               m_indexed_block_map->hasIndexedBlock(name);
     }
 
-    std::shared_ptr<const IndexedBlock> getIndexedBlock(const std::string& name);
+    std::shared_ptr<const IndexedBlock>
+    getIndexedBlock(const std::string& name);
 
     void addBlock(std::shared_ptr<Block> b) { m_sub_block[b->getName()] = b; }
 

--- a/Reader.cpp
+++ b/Reader.cpp
@@ -21,8 +21,8 @@ Reader::Reader(std::string fname, size_t buffer_size)
         m_mae_parser.reset(new MaeParser(stream, buffer_size));
     } else if (ends_with(fname, ".maegz") || ends_with(fname, ".mae.gz")) {
         m_pregzip_stream = stream; // Store it since maeparser won't
-        m_gzip_stream = std::make_shared<
-            boost::iostreams::filtering_istreambuf>();
+        m_gzip_stream =
+            std::make_shared<boost::iostreams::filtering_istreambuf>();
         m_gzip_stream->push(boost::iostreams::gzip_decompressor());
         m_gzip_stream->push(*stream);
         auto decompressed_stream =

--- a/Writer.cpp
+++ b/Writer.cpp
@@ -1,8 +1,8 @@
 #include "Writer.hpp"
 
+#include <boost/algorithm/string/predicate.hpp>
 #include <fstream>
 #include <iostream>
-#include <boost/algorithm/string/predicate.hpp>
 
 #include "MaeBlock.hpp"
 
@@ -26,7 +26,8 @@ Writer::Writer(std::string fname)
     pregzip_stream->open(fname, std::ios_base::out | std::ios_base::binary);
 
     if (ends_with(fname, ".maegz") || ends_with(fname, ".mae.gz")) {
-        m_gzip_stream = std::make_shared<boost::iostreams::filtering_ostreambuf>();
+        m_gzip_stream =
+            std::make_shared<boost::iostreams::filtering_ostreambuf>();
         m_gzip_compressor = make_shared<boost::iostreams::gzip_compressor>();
         m_gzip_stream->push(*m_gzip_compressor);
         m_gzip_stream->push(*pregzip_stream);

--- a/Writer.hpp
+++ b/Writer.hpp
@@ -7,7 +7,6 @@
 
 #include "MaeParserConfig.hpp"
 
-
 namespace schrodinger
 {
 namespace mae

--- a/test/MaeBlockTest.cpp
+++ b/test/MaeBlockTest.cpp
@@ -216,8 +216,8 @@ std::shared_ptr<mae::IndexedBlock> getExampleIndexedBlock()
     boost::dynamic_bitset<>* rbs = new boost::dynamic_bitset<>(3);
     rbs->set(2);
 
-    auto irps = std::shared_ptr<IndexedRealProperty>(
-            new IndexedRealProperty(rv, rbs));
+    auto irps =
+        std::shared_ptr<IndexedRealProperty>(new IndexedRealProperty(rv, rbs));
     ib->setRealProperty("r_m_reals", irps);
 
     return ib;
@@ -225,8 +225,8 @@ std::shared_ptr<mae::IndexedBlock> getExampleIndexedBlock()
 
 BOOST_AUTO_TEST_CASE(toStringProperties)
 {
-    const std::string rval = \
-R"(dummy {
+    const std::string rval =
+        R"(dummy {
   b_m_bool
   r_m_real
   i_m_int
@@ -267,8 +267,8 @@ R"(dummy {
 BOOST_AUTO_TEST_CASE(toStringIndexedProperties)
 {
     using namespace mae;
-    const std::string rval = \
-R"(m_atom[3] {
+    const std::string rval =
+        R"(m_atom[3] {
   # First column is Index #
   b_m_bool
   r_m_reals
@@ -284,6 +284,5 @@ R"(m_atom[3] {
 
     BOOST_REQUIRE_EQUAL(ib->toString(), rval);
 }
-
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/MaeParserTest.cpp
+++ b/test/MaeParserTest.cpp
@@ -6,8 +6,8 @@
 
 #include "Buffer.hpp"
 #include "MaeBlock.hpp"
-#include "MaeParser.hpp"
 #include "MaeConstants.hpp"
+#include "MaeParser.hpp"
 
 using namespace schrodinger;
 using namespace schrodinger::mae;

--- a/test/ReaderTest.cpp
+++ b/test/ReaderTest.cpp
@@ -6,8 +6,8 @@
 #include <boost/test/unit_test.hpp>
 
 #include "MaeBlock.hpp"
-#include "Reader.hpp"
 #include "MaeConstants.hpp"
+#include "Reader.hpp"
 
 using namespace schrodinger::mae;
 using std::shared_ptr;
@@ -290,7 +290,6 @@ BOOST_AUTO_TEST_CASE(DirectReader)
     }
     fclose(f);
     BOOST_REQUIRE_EQUAL(count, 3u);
-
 }
 
 BOOST_AUTO_TEST_CASE(QuotedStringTest)

--- a/test/UsageDemo.cpp
+++ b/test/UsageDemo.cpp
@@ -17,8 +17,8 @@
 #include <unordered_map>
 #include <vector>
 
-#include "Reader.hpp"
 #include "MaeConstants.hpp"
+#include "Reader.hpp"
 
 #define BOOST_TEST_DYN_LINK
 
@@ -73,7 +73,8 @@ BOOST_AUTO_TEST_CASE(maeBlock)
         {
             const auto atom_data = b->getIndexedBlock(ATOM_BLOCK);
             // All atoms are gauranteed to have these three field names:
-            const auto atomic_numbers = atom_data->getIntProperty(ATOM_ATOMIC_NUM);
+            const auto atomic_numbers =
+                atom_data->getIntProperty(ATOM_ATOMIC_NUM);
             const auto xs = atom_data->getRealProperty(ATOM_X_COORD);
             const auto ys = atom_data->getRealProperty(ATOM_Y_COORD);
             const auto zs = atom_data->getRealProperty(ATOM_Z_COORD);

--- a/test/WriterTest.cpp
+++ b/test/WriterTest.cpp
@@ -4,9 +4,9 @@
 #include <iostream>
 
 #include "MaeBlock.hpp"
+#include "MaeConstants.hpp"
 #include "Reader.hpp"
 #include "Writer.hpp"
-#include "MaeConstants.hpp"
 
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
@@ -20,7 +20,7 @@ BOOST_AUTO_TEST_CASE(Writer0)
 {
     Reader r("test.mae");
     auto w = std::make_shared<Writer>("test_write.mae");
-    std::vector<std::shared_ptr<Block> > input;
+    std::vector<std::shared_ptr<Block>> input;
 
     std::shared_ptr<Block> b;
     while ((b = r.next(CT_BLOCK)) != nullptr) {
@@ -34,14 +34,13 @@ BOOST_AUTO_TEST_CASE(Writer0)
     while ((b = output_r.next(CT_BLOCK)) != nullptr) {
         BOOST_CHECK(*b == *(input[input_num++]));
     }
-
 }
 
 BOOST_AUTO_TEST_CASE(Writer1)
 {
     Reader r("test.mae");
     auto w = std::make_shared<Writer>("test_write.maegz");
-    std::vector<std::shared_ptr<Block> > input;
+    std::vector<std::shared_ptr<Block>> input;
 
     std::shared_ptr<Block> b;
     while ((b = r.next(CT_BLOCK)) != nullptr) {
@@ -55,7 +54,6 @@ BOOST_AUTO_TEST_CASE(Writer1)
     while ((b = output_r.next(CT_BLOCK)) != nullptr) {
         BOOST_CHECK(*b == *(input[input_num++]));
     }
-
 }
 
 /*


### PR DESCRIPTION
Apparently, some files had been comitted without proper clang formatting.

All changes in this PR are due only to applying clang-format to all *.cpp and *.hpp files in the repo.

This will make it easier to review upcoming PRs (as long as these are clang-formatted).