### PR TITLE
Have the tests run in the build directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ if(MSVC)
     add_definitions(/wd4251 /D_SCL_SECURE_NO_WARNINGS /D_CRT_SECURE_NO_WARNINGS)
 endif(MSVC)
 
-find_package(Boost COMPONENTS iostreams unit_test_framework REQUIRED)
+find_package(Boost COMPONENTS filesystem iostreams unit_test_framework REQUIRED)
 
 include_directories(${Boost_INCLUDE_DIRS})
 
@@ -40,9 +40,6 @@ set_property(TARGET maeparser PROPERTY CXX_VISIBILITY_PRESET "hidden")
 
 enable_testing()
 add_subdirectory(test)
-
-add_test(NAME unittest COMMAND ${CMAKE_BINARY_DIR}/test/unittest
-         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test)
 
 install(FILES Buffer.hpp MaeBlock.hpp  MaeParserConfig.hpp  MaeParser.hpp  Reader.hpp MaeConstants.hpp
         DESTINATION include/maeparser)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,7 +3,13 @@ include_directories(..)
 add_executable(unittest
     MainTestSuite.cpp BufferTest.cpp MaeBlockTest.cpp MaeParserTest.cpp ReaderTest.cpp WriterTest.cpp UsageDemo.cpp)
 
-target_link_libraries(unittest maeparser Boost::unit_test_framework)
+target_link_libraries(unittest maeparser Boost::unit_test_framework Boost::filesystem)
+
+set(TEST_SAMPLES test.mae test2.maegz )
+file(COPY ${TEST_SAMPLES} DESTINATION ${CMAKE_BINARY_DIR}/test/samples)
+
+add_test(NAME unittest COMMAND ${CMAKE_BINARY_DIR}/test/unittest
+         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/test)
 
 if(MSVC)
     add_custom_command(TARGET unittest POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,8 +5,8 @@ add_executable(unittest
 
 target_link_libraries(unittest maeparser Boost::unit_test_framework Boost::filesystem)
 
-set(TEST_SAMPLES test.mae test2.maegz )
-file(COPY ${TEST_SAMPLES} DESTINATION ${CMAKE_BINARY_DIR}/test/samples)
+get_filename_component(TEST_SAMPLES_PATH ${CMAKE_CURRENT_SOURCE_DIR} ABSOLUTE)
+target_compile_definitions(unittest PRIVATE "TEST_SAMPLES_PATH=\"${TEST_SAMPLES_PATH}\"")
 
 add_test(NAME unittest COMMAND ${CMAKE_BINARY_DIR}/test/unittest
          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/test)

--- a/test/ReaderTest.cpp
+++ b/test/ReaderTest.cpp
@@ -214,7 +214,7 @@ BOOST_AUTO_TEST_CASE(NestedIndexedBlock)
 
 BOOST_AUTO_TEST_CASE(BufferedReader)
 {
-    auto ss = std::make_shared<std::ifstream>("test.mae");
+    auto ss = std::make_shared<std::ifstream>("samples/test.mae");
 
     Reader r(ss);
 
@@ -230,7 +230,7 @@ BOOST_AUTO_TEST_CASE(BufferedReader)
 
 BOOST_AUTO_TEST_CASE(BufferedFileReader)
 {
-    FILE* f = fopen("test.mae", "r");
+    FILE* f = fopen("samples/test.mae", "r");
 
     Reader r(f);
 
@@ -247,7 +247,7 @@ BOOST_AUTO_TEST_CASE(BufferedFileReader)
 
 BOOST_AUTO_TEST_CASE(TextReader)
 {
-    auto ss = std::make_shared<std::ifstream>("test.mae");
+    auto ss = std::make_shared<std::ifstream>("samples/test.mae");
 
     Reader r(ss);
 
@@ -261,7 +261,7 @@ BOOST_AUTO_TEST_CASE(TextReader)
 
 BOOST_AUTO_TEST_CASE(TextFileReader)
 {
-    FILE* f = fopen("test.mae", "r");
+    FILE* f = fopen("samples/test.mae", "r");
 
     Reader r(f);
 
@@ -276,7 +276,7 @@ BOOST_AUTO_TEST_CASE(TextFileReader)
 
 BOOST_AUTO_TEST_CASE(DirectReader)
 {
-    FILE* f = fopen("test.mae", "r");
+    FILE* f = fopen("samples/test.mae", "r");
     auto mae_parser = std::make_shared<DirectMaeParser>(f);
 
     Reader r(mae_parser);
@@ -294,7 +294,7 @@ BOOST_AUTO_TEST_CASE(DirectReader)
 
 BOOST_AUTO_TEST_CASE(QuotedStringTest)
 {
-    FILE* f = fopen("test.mae", "r");
+    FILE* f = fopen("samples/test.mae", "r");
 
     Reader r(f);
 

--- a/test/ReaderTest.cpp
+++ b/test/ReaderTest.cpp
@@ -4,6 +4,7 @@
 
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
+#include <boost/filesystem.hpp>
 
 #include "MaeBlock.hpp"
 #include "MaeConstants.hpp"
@@ -11,6 +12,10 @@
 
 using namespace schrodinger::mae;
 using std::shared_ptr;
+
+const boost::filesystem::path test_samples_path(TEST_SAMPLES_PATH);
+const std::string uncompressed_sample =
+    (test_samples_path / "test.mae").string();
 
 BOOST_AUTO_TEST_SUITE(ReaderSuite)
 
@@ -214,7 +219,7 @@ BOOST_AUTO_TEST_CASE(NestedIndexedBlock)
 
 BOOST_AUTO_TEST_CASE(BufferedReader)
 {
-    auto ss = std::make_shared<std::ifstream>("samples/test.mae");
+    auto ss = std::make_shared<std::ifstream>(uncompressed_sample);
 
     Reader r(ss);
 
@@ -230,7 +235,8 @@ BOOST_AUTO_TEST_CASE(BufferedReader)
 
 BOOST_AUTO_TEST_CASE(BufferedFileReader)
 {
-    FILE* f = fopen("samples/test.mae", "r");
+
+    FILE* f = fopen(uncompressed_sample.c_str(), "r");
 
     Reader r(f);
 
@@ -247,7 +253,7 @@ BOOST_AUTO_TEST_CASE(BufferedFileReader)
 
 BOOST_AUTO_TEST_CASE(TextReader)
 {
-    auto ss = std::make_shared<std::ifstream>("samples/test.mae");
+    auto ss = std::make_shared<std::ifstream>(uncompressed_sample);
 
     Reader r(ss);
 
@@ -261,7 +267,7 @@ BOOST_AUTO_TEST_CASE(TextReader)
 
 BOOST_AUTO_TEST_CASE(TextFileReader)
 {
-    FILE* f = fopen("samples/test.mae", "r");
+    FILE* f = fopen(uncompressed_sample.c_str(), "r");
 
     Reader r(f);
 
@@ -276,7 +282,7 @@ BOOST_AUTO_TEST_CASE(TextFileReader)
 
 BOOST_AUTO_TEST_CASE(DirectReader)
 {
-    FILE* f = fopen("samples/test.mae", "r");
+    FILE* f = fopen(uncompressed_sample.c_str(), "r");
     auto mae_parser = std::make_shared<DirectMaeParser>(f);
 
     Reader r(mae_parser);
@@ -294,7 +300,7 @@ BOOST_AUTO_TEST_CASE(DirectReader)
 
 BOOST_AUTO_TEST_CASE(QuotedStringTest)
 {
-    FILE* f = fopen("samples/test.mae", "r");
+    FILE* f = fopen(uncompressed_sample.c_str(), "r");
 
     Reader r(f);
 

--- a/test/UsageDemo.cpp
+++ b/test/UsageDemo.cpp
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_SUITE(DemoSuite)
 // exist in every f_m_ct block.
 BOOST_AUTO_TEST_CASE(maeBlock)
 {
-    schrodinger::mae::Reader r("test2.maegz");
+    schrodinger::mae::Reader r("samples/test2.maegz");
 
     std::vector<std::shared_ptr<Structure>> structures;
     std::shared_ptr<Block> b;

--- a/test/UsageDemo.cpp
+++ b/test/UsageDemo.cpp
@@ -23,6 +23,7 @@
 #define BOOST_TEST_DYN_LINK
 
 #include <boost/test/unit_test.hpp>
+#include <boost/filesystem.hpp>
 
 using namespace schrodinger::mae;
 
@@ -54,6 +55,10 @@ class Structure
     std::unordered_map<int, int> demo_property;
 };
 
+const boost::filesystem::path test_samples_path(TEST_SAMPLES_PATH);
+const std::string compressed_sample =
+    (test_samples_path / "test2.maegz").string();
+
 BOOST_AUTO_TEST_SUITE(DemoSuite)
 
 // Reads all atom and bond information from test.mae, which is a standard
@@ -61,7 +66,7 @@ BOOST_AUTO_TEST_SUITE(DemoSuite)
 // exist in every f_m_ct block.
 BOOST_AUTO_TEST_CASE(maeBlock)
 {
-    schrodinger::mae::Reader r("samples/test2.maegz");
+    schrodinger::mae::Reader r(compressed_sample);
 
     std::vector<std::shared_ptr<Structure>> structures;
     std::shared_ptr<Block> b;

--- a/test/WriterTest.cpp
+++ b/test/WriterTest.cpp
@@ -10,15 +10,37 @@
 
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
+#include <boost/filesystem.hpp>
 
 using namespace schrodinger::mae;
 using std::shared_ptr;
+
+// We should make sure these do not exist before the tests starts,
+// this will prevent any chances of finding the results of an older test.
+const std::vector<std::string> generated_files = {"test_write.mae",
+                                                  "test_write.maegz"};
+
+class WriterGlobalFixture
+{
+  public:
+    WriterGlobalFixture()
+    {
+        for (auto& file : generated_files) {
+            boost::filesystem::path fpath(file);
+            if (boost::filesystem::exists(fpath)) {
+                boost::filesystem::remove(fpath);
+            }
+        }
+    }
+};
+
+BOOST_GLOBAL_FIXTURE(WriterGlobalFixture);
 
 BOOST_AUTO_TEST_SUITE(WriterSuite)
 
 BOOST_AUTO_TEST_CASE(Writer0)
 {
-    Reader r("test.mae");
+    Reader r("samples/test.mae");
     auto w = std::make_shared<Writer>("test_write.mae");
     std::vector<std::shared_ptr<Block>> input;
 
@@ -38,7 +60,7 @@ BOOST_AUTO_TEST_CASE(Writer0)
 
 BOOST_AUTO_TEST_CASE(Writer1)
 {
-    Reader r("test.mae");
+    Reader r("samples/test.mae");
     auto w = std::make_shared<Writer>("test_write.maegz");
     std::vector<std::shared_ptr<Block>> input;
 
@@ -60,7 +82,7 @@ BOOST_AUTO_TEST_CASE(Writer1)
 // UNCOMMENT BLOCK TO TEST PERFORMANCE OF LIGAND WRITING
 BOOST_AUTO_TEST_CASE(PerfTest)
 {
-    Reader r("test.mae");
+    Reader r("samples/test.mae");
     auto w = std::make_shared<Writer>("test_write.maegz");
     std::vector<std::shared_ptr<Block> > input;
 

--- a/test/WriterTest.cpp
+++ b/test/WriterTest.cpp
@@ -20,6 +20,10 @@ using std::shared_ptr;
 const std::vector<std::string> generated_files = {"test_write.mae",
                                                   "test_write.maegz"};
 
+const boost::filesystem::path test_samples_path(TEST_SAMPLES_PATH);
+const std::string uncompressed_sample =
+    (test_samples_path / "test.mae").string();
+
 class WriterGlobalFixture
 {
   public:
@@ -40,7 +44,7 @@ BOOST_AUTO_TEST_SUITE(WriterSuite)
 
 BOOST_AUTO_TEST_CASE(Writer0)
 {
-    Reader r("samples/test.mae");
+    Reader r(uncompressed_sample);
     auto w = std::make_shared<Writer>("test_write.mae");
     std::vector<std::shared_ptr<Block>> input;
 
@@ -60,7 +64,7 @@ BOOST_AUTO_TEST_CASE(Writer0)
 
 BOOST_AUTO_TEST_CASE(Writer1)
 {
-    Reader r("samples/test.mae");
+    Reader r(uncompressed_sample);
     auto w = std::make_shared<Writer>("test_write.maegz");
     std::vector<std::shared_ptr<Block>> input;
 
@@ -82,7 +86,7 @@ BOOST_AUTO_TEST_CASE(Writer1)
 // UNCOMMENT BLOCK TO TEST PERFORMANCE OF LIGAND WRITING
 BOOST_AUTO_TEST_CASE(PerfTest)
 {
-    Reader r("samples/test.mae");
+    Reader r(uncompressed_sample);
     auto w = std::make_shared<Writer>("test_write.maegz");
     std::vector<std::shared_ptr<Block> > input;
 


### PR DESCRIPTION
Two changes:
- Changes in CMake files to run the tests in the build directory. For this, the sample mae files are copied into {build_dir}/test/samples.
- Before running the write test, check for, and eventually remove leftover output files from other runs. This prevents that a test that didn't write out anything find older outputs.

Notes: If at some point we add more tests to the writer, we should remember to make sure that any files that get written are in the 'genrated_files' vector.