### PR TITLE
Fix leaks and refactor Writer class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,11 @@ target_compile_definitions(maeparser PRIVATE IN_MAEPARSER)
 
 set_property(TARGET maeparser PROPERTY CXX_VISIBILITY_PRESET "hidden")
 
-enable_testing()
+set(MEMORYCHECK_COMMAND_OPTIONS "${MEMORYCHECK_COMMAND_OPTIONS} --tool=memcheck \
+        --time-stamp=yes --num-callers=20 --gen-suppressions=all --leak-check=full \
+        --show-reachable=yes --trace-children=yes --error-exitcode=29")
+
+include(CTest)
 add_subdirectory(test)
 
 add_test(NAME unittest COMMAND ${CMAKE_BINARY_DIR}/test/unittest

--- a/Writer.cpp
+++ b/Writer.cpp
@@ -28,7 +28,7 @@ Writer::Writer(std::shared_ptr<ostream> stream)
 
 Writer::Writer(std::string fname)
 {
-    constexpr auto ios_mode = std::ios_base::out | std::ios_base::binary;
+    const auto ios_mode = std::ios_base::out | std::ios_base::binary;
 
     if (ends_with(fname, ".maegz") || ends_with(fname, ".mae.gz")) {
         auto* gzip_stream = new filtering_ostream();

--- a/Writer.cpp
+++ b/Writer.cpp
@@ -1,6 +1,10 @@
 #include "Writer.hpp"
 
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/iostreams/filter/gzip.hpp>
+#include <boost/iostreams/filtering_stream.hpp>
+#include <boost/iostreams/device/file.hpp>
+
 #include <fstream>
 #include <iostream>
 
@@ -8,6 +12,8 @@
 
 using namespace std;
 using boost::algorithm::ends_with;
+using boost::iostreams::filtering_ostream;
+using boost::iostreams::file_sink;
 
 namespace schrodinger
 {
@@ -22,19 +28,18 @@ Writer::Writer(std::shared_ptr<ostream> stream)
 
 Writer::Writer(std::string fname)
 {
-    auto pregzip_stream = new ofstream();
-    pregzip_stream->open(fname, std::ios_base::out | std::ios_base::binary);
+    constexpr auto ios_mode = std::ios_base::out | std::ios_base::binary;
 
     if (ends_with(fname, ".maegz") || ends_with(fname, ".mae.gz")) {
-        m_gzip_stream =
-            std::make_shared<boost::iostreams::filtering_ostreambuf>();
-        m_gzip_compressor = make_shared<boost::iostreams::gzip_compressor>();
-        m_gzip_stream->push(*m_gzip_compressor);
-        m_gzip_stream->push(*pregzip_stream);
-        m_out = std::make_shared<std::ostream>(m_gzip_stream.get());
+        auto* gzip_stream = new filtering_ostream();
+        gzip_stream->push(boost::iostreams::gzip_compressor());
+        gzip_stream->push(file_sink(fname, ios_mode));
+        m_out.reset(static_cast<ostream*>(gzip_stream));
     } else {
-        m_out.reset(dynamic_cast<ostream*>(pregzip_stream));
+        auto* file_stream = new ofstream(fname, ios_mode);
+        m_out.reset(static_cast<ostream*>(file_stream));
     }
+
     write_opening_block();
 }
 

--- a/Writer.hpp
+++ b/Writer.hpp
@@ -1,9 +1,8 @@
 #pragma once
 
-#include <boost/iostreams/filter/gzip.hpp>
-#include <boost/iostreams/filtering_streambuf.hpp>
 #include <cstdio>
 #include <string>
+#include <memory>
 
 #include "MaeParserConfig.hpp"
 
@@ -17,15 +16,14 @@ class Block;
 class EXPORT_MAEPARSER Writer
 {
   private:
-    std::shared_ptr<boost::iostreams::filtering_ostreambuf> m_gzip_stream;
-    std::shared_ptr<boost::iostreams::gzip_compressor> m_gzip_compressor;
-    std::shared_ptr<std::ostream> m_out;
+    std::shared_ptr<std::ostream> m_out = nullptr;
 
     void write_opening_block();
 
   public:
+    Writer() = delete;
+    explicit Writer(std::string fname);
     Writer(std::shared_ptr<std::ostream> stream);
-    Writer(std::string fname);
 
     void write(const std::shared_ptr<Block>& block);
 };


### PR DESCRIPTION
The leaks found in the tests happened due to the Writer class. This patch fixes them and adds some refactoring which makes the class neater.

Changes:
- Enable memtesting in tests.
- Refactor Writer: use a boost::iostreams::filtering_ostream, instead of a filtering_ostreambuf. This change allows us to get rid of m_gzip_stream. We also don't need to store m_gzip_compressor, since the filtering_ostream can take care of it.