### PR TITLE
Refactor the Reader class

### DIFF
--- a/Reader.cpp
+++ b/Reader.cpp
@@ -1,35 +1,52 @@
 #include "Reader.hpp"
 
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/iostreams/device/file.hpp>
 #include <boost/iostreams/filter/gzip.hpp>
-#include <boost/iostreams/filtering_streambuf.hpp>
+#include <boost/iostreams/filtering_stream.hpp>
+
 #include <fstream>
 #include <iostream>
 
 using boost::algorithm::ends_with;
+using boost::iostreams::file_source;
+using boost::iostreams::filtering_istream;
 
 namespace schrodinger
 {
 namespace mae
 {
 
-Reader::Reader(std::string fname, size_t buffer_size)
+Reader::Reader(FILE* file, size_t buffer_size)
 {
-    auto stream = std::make_shared<std::ifstream>(
-        fname, std::ios_base::in | std::ios_base::binary);
-    if (ends_with(fname, ".mae")) {
-        m_mae_parser.reset(new MaeParser(stream, buffer_size));
-    } else if (ends_with(fname, ".maegz") || ends_with(fname, ".mae.gz")) {
-        m_pregzip_stream = stream; // Store it since maeparser won't
-        m_gzip_stream =
-            std::make_shared<boost::iostreams::filtering_istreambuf>();
-        m_gzip_stream->push(boost::iostreams::gzip_decompressor());
-        m_gzip_stream->push(*stream);
-        auto decompressed_stream =
-            std::make_shared<std::istream>(m_gzip_stream.get());
-        m_mae_parser =
-            std::make_shared<MaeParser>(decompressed_stream, buffer_size);
+    m_mae_parser.reset(new MaeParser(file, buffer_size));
+}
+
+Reader::Reader(std::shared_ptr<std::istream> stream, size_t buffer_size)
+{
+    m_mae_parser.reset(new MaeParser(stream, buffer_size));
+}
+
+Reader::Reader(const std::string& fname, size_t buffer_size)
+{
+    const auto ios_mode = std::ios_base::in | std::ios_base::binary;
+
+    std::shared_ptr<std::istream> stream;
+    if (ends_with(fname, ".maegz") || ends_with(fname, ".mae.gz")) {
+        auto* gzip_stream = new filtering_istream();
+        gzip_stream->push(boost::iostreams::gzip_decompressor());
+        gzip_stream->push(file_source(fname, ios_mode));
+        stream.reset(static_cast<std::istream*>(gzip_stream));
+    } else {
+        auto* file_stream = new std::ifstream(fname, ios_mode);
+        stream.reset(static_cast<std::istream*>(file_stream));
     }
+
+    m_mae_parser.reset(new MaeParser(stream, buffer_size));
+}
+
+Reader::Reader(std::shared_ptr<MaeParser> mae_parser) : m_mae_parser(mae_parser)
+{
 }
 
 std::shared_ptr<Block> Reader::next(const std::string& outer_block_name)

--- a/Reader.hpp
+++ b/Reader.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <boost/iostreams/filtering_streambuf.hpp>
 #include <cstdio>
+#include <memory>
 #include <string>
 
 #include "Buffer.hpp"
@@ -18,27 +18,21 @@ class EXPORT_MAEPARSER Reader
 {
   private:
     std::shared_ptr<MaeParser> m_mae_parser;
-    std::shared_ptr<std::ifstream> m_pregzip_stream;
-    std::shared_ptr<boost::iostreams::filtering_istreambuf> m_gzip_stream;
 
   public:
-    Reader(FILE* file, size_t buffer_size = BufferLoader::DEFAULT_SIZE)
-    {
-        m_mae_parser.reset(new MaeParser(file, buffer_size));
-    }
+    Reader() = delete;
+    Reader(FILE* file, size_t buffer_size = BufferLoader::DEFAULT_SIZE);
 
     Reader(std::shared_ptr<std::istream> stream,
-           size_t buffer_size = BufferLoader::DEFAULT_SIZE)
-    {
-        m_mae_parser.reset(new MaeParser(stream, buffer_size));
-    }
+           size_t buffer_size = BufferLoader::DEFAULT_SIZE);
 
-    Reader(std::string fname, size_t buffer_size = BufferLoader::DEFAULT_SIZE);
+    Reader(const std::string& fname,
+           size_t buffer_size = BufferLoader::DEFAULT_SIZE);
 
     // Should be made private if we conclude there's no need for the
     // DirectParser. The only current purpose of allowing construction from a
     // MaeParser is to allow direct/buffered behavior difference.
-    Reader(std::shared_ptr<MaeParser> mae_parser) : m_mae_parser(mae_parser) {}
+    Reader(std::shared_ptr<MaeParser> mae_parser);
 
     std::shared_ptr<Block> next(const std::string& outer_block_name);
 };

--- a/Writer.cpp
+++ b/Writer.cpp
@@ -10,6 +10,7 @@
 
 #include "MaeBlock.hpp"
 
+using namespace std;
 using boost::algorithm::ends_with;
 using boost::iostreams::filtering_ostream;
 using boost::iostreams::file_sink;

--- a/Writer.cpp
+++ b/Writer.cpp
@@ -10,7 +10,6 @@
 
 #include "MaeBlock.hpp"
 
-using namespace std;
 using boost::algorithm::ends_with;
 using boost::iostreams::filtering_ostream;
 using boost::iostreams::file_sink;
@@ -20,13 +19,12 @@ namespace schrodinger
 namespace mae
 {
 
-Writer::Writer(std::shared_ptr<ostream> stream)
+Writer::Writer(std::shared_ptr<ostream> stream) : m_out(stream)
 {
-    m_out = stream;
     write_opening_block();
 }
 
-Writer::Writer(std::string fname)
+Writer::Writer(const std::string& fname)
 {
     const auto ios_mode = std::ios_base::out | std::ios_base::binary;
 

--- a/Writer.hpp
+++ b/Writer.hpp
@@ -22,7 +22,7 @@ class EXPORT_MAEPARSER Writer
 
   public:
     Writer() = delete;
-    explicit Writer(std::string fname);
+    explicit Writer(const std::string& fname);
     Writer(std::shared_ptr<std::ostream> stream);
 
     void write(const std::shared_ptr<Block>& block);


### PR DESCRIPTION
This refactors the Reader class in a similar fashion to the recent changes to the Writer class.

Basically, the changes consist in using a boost::iltering_istream instead of a boost::filtering_istreambuf, so that we can get rid of a couple of data members.

I also made a couple of changes to the Writer class that I missed in the previous PR.