### PR TITLE
Add getProperyNames() functions to Block and Indexed Block.

### DIFF
--- a/MaeBlock.cpp
+++ b/MaeBlock.cpp
@@ -129,6 +129,31 @@ shared_ptr<const IndexedBlock> Block::getIndexedBlock(const string& name)
         m_indexed_block_map->getIndexedBlock(name));
 }
 
+template <>
+const std::map<std::string, BoolProperty>&
+Block::getProperties<BoolProperty>() const
+{
+    return m_bmap;
+}
+
+template <> const std::map<std::string, int>& Block::getProperties<int>() const
+{
+    return m_imap;
+}
+
+template <>
+const std::map<std::string, double>& Block::getProperties<double>() const
+{
+    return m_rmap;
+}
+
+template <>
+const std::map<std::string, std::string>&
+Block::getProperties<std::string>() const
+{
+    return m_smap;
+}
+
 bool real_map_equal(const map<string, double>& rmap1,
                     const map<string, double>& rmap2)
 {
@@ -394,6 +419,34 @@ bool IndexedBlock::operator==(const IndexedBlock& rhs) const
         return false;
 
     return true;
+}
+
+template <>
+const std::map<std::string, std::shared_ptr<IndexedProperty<BoolProperty>>>&
+IndexedBlock::getProperties() const
+{
+    return m_bmap;
+}
+
+template <>
+const std::map<std::string, std::shared_ptr<IndexedProperty<int>>>&
+IndexedBlock::getProperties() const
+{
+    return m_imap;
+}
+
+template <>
+const std::map<std::string, std::shared_ptr<IndexedProperty<double>>>&
+IndexedBlock::getProperties() const
+{
+    return m_rmap;
+}
+
+template <>
+const std::map<std::string, std::shared_ptr<IndexedProperty<std::string>>>&
+IndexedBlock::getProperties() const
+{
+    return m_smap;
 }
 
 } // namespace mae

--- a/MaeBlock.hpp
+++ b/MaeBlock.hpp
@@ -238,6 +238,15 @@ class EXPORT_MAEPARSER Block
     {
         m_smap[name] = value;
     }
+
+    template <typename T> const std::map<std::string, T>& getProperties() const;
+#ifdef WIN32
+    template <>
+    const std::map<std::string, BoolProperty>& getProperties() const;
+    template <> const std::map<std::string, int>& getProperties() const;
+    template <> const std::map<std::string, double>& getProperties() const;
+    template <> const std::map<std::string, std::string>& getProperties() const;
+#endif
 };
 
 template <typename T> class IndexedProperty
@@ -475,6 +484,24 @@ class EXPORT_MAEPARSER IndexedBlock
     {
         set_indexed_property<IndexedStringProperty>(m_smap, name, value);
     }
+
+    template <typename T>
+    const std::map<std::string, std::shared_ptr<IndexedProperty<T>>>&
+    getProperties() const;
+#ifdef WIN32
+    template <>
+    const std::map<std::string, std::shared_ptr<IndexedProperty<BoolProperty>>>&
+    getProperties() const;
+    template <>
+    const std::map<std::string, std::shared_ptr<IndexedProperty<int>>>&
+    getProperties() const;
+    template <>
+    const std::map<std::string, std::shared_ptr<IndexedProperty<double>>>&
+    getProperties() const;
+    template <>
+    const std::map<std::string, std::shared_ptr<IndexedProperty<std::string>>>&
+    getProperties() const;
+#endif
 };
 
 } // namespace mae

--- a/test/MaeBlockTest.cpp
+++ b/test/MaeBlockTest.cpp
@@ -42,6 +42,25 @@ BOOST_AUTO_TEST_CASE(maeBlock)
         BOOST_REQUIRE_EQUAL(b.getStringProperty("a"), value);
         BOOST_REQUIRE_THROW(b.getStringProperty("b"), std::out_of_range);
     }
+
+    // All the properties we set have the same name, but different types
+    const std::string property_name("a");
+
+    auto bool_props = b.getProperties<mae::BoolProperty>();
+    BOOST_CHECK_EQUAL(bool_props.size(), 1u);
+    BOOST_CHECK_EQUAL(bool_props.begin()->first, property_name);
+
+    auto int_props = b.getProperties<int>();
+    BOOST_CHECK_EQUAL(int_props.size(), 1u);
+    BOOST_CHECK_EQUAL(int_props.begin()->first, property_name);
+
+    auto double_props = b.getProperties<double>();
+    BOOST_CHECK_EQUAL(double_props.size(), 1u);
+    BOOST_CHECK_EQUAL(double_props.begin()->first, property_name);
+
+    auto string_props = b.getProperties<std::string>();
+    BOOST_CHECK_EQUAL(string_props.size(), 1u);
+    BOOST_CHECK_EQUAL(string_props.begin()->first, property_name);
 }
 
 BOOST_AUTO_TEST_CASE(maeIndexedRealProperty)
@@ -262,6 +281,24 @@ BOOST_AUTO_TEST_CASE(toStringProperties)
     b.setIndexedBlockMap(ibm);
 
     BOOST_REQUIRE_EQUAL(b.toString(), rval);
+
+    // All the properties we set have the same name, but different types
+
+    auto bool_props = b.getProperties<mae::BoolProperty>();
+    BOOST_CHECK_EQUAL(bool_props.size(), 1u);
+    BOOST_CHECK_EQUAL(bool_props.begin()->first, std::string("b_m_bool"));
+
+    auto int_props = b.getProperties<int>();
+    BOOST_CHECK_EQUAL(int_props.size(), 1u);
+    BOOST_CHECK_EQUAL(int_props.begin()->first, std::string("i_m_int"));
+
+    auto double_props = b.getProperties<double>();
+    BOOST_CHECK_EQUAL(double_props.size(), 1u);
+    BOOST_CHECK_EQUAL(double_props.begin()->first, std::string("r_m_real"));
+
+    auto string_props = b.getProperties<std::string>();
+    BOOST_CHECK_EQUAL(string_props.size(), 1u);
+    BOOST_CHECK_EQUAL(string_props.begin()->first, std::string("s_m_string"));
 }
 
 BOOST_AUTO_TEST_CASE(toStringIndexedProperties)


### PR DESCRIPTION
Addresses #41 

Using these functions, we can recover a list of the properties stored in the block.

Given the way properties are stored, duplicated names are allowed if they have different types, so, to disambiguate, it is required to provide a hint of the data type each property is associated. These hints are provided as the initial of the data type: 'b' for boolean, 'i' for integer, 'r' for real number, and 's' for string.

Also, a couple of unrelated improvements: making Block m_name const, use std::move to initialize Block and IndexedBlock m_names, and delete the copy constructor and assignment operator.