### PR TITLE
Refactoring of MaeBlock hpp & cpp

### DIFF
--- a/MaeBlock.cpp
+++ b/MaeBlock.cpp
@@ -31,7 +31,7 @@ string local_to_string(const string& val)
         return R"("")";
     }
 
-    // Quotes are required if any character need escaping, or there are
+    // Quotes are required if any character needs escaping, or there are
     // spaces in the string (spaces do not require escaping)
     bool quotes_required = false;
     for (const char& c : val) {

--- a/MaeBlock.cpp
+++ b/MaeBlock.cpp
@@ -10,47 +10,56 @@ namespace schrodinger
 namespace mae
 {
 
-static const double tolerance = 0.00001; // Tolerance to match string cutoff
+namespace
+{
+const double tolerance = 0.00001; // Tolerance to match string cutoff
 
 // Wrap to-string to allow it to take strings and be a no-op
-template <typename T> static string local_to_string(T val)
+template <typename T> inline string local_to_string(T val)
 {
     return to_string(val);
 }
 
-static string local_to_string(string val)
+inline bool char_requires_escaping(char c)
 {
-    if (val.length() == 0)
+    return c == '"' || c == '\\' || c == ' ';
+}
+
+string local_to_string(const string& val)
+{
+    if (val.empty()) {
         return R"("")";
+    }
+
     // Create new string big enough to escape every character and add quotes
-    size_t pos_in_old = 0;
     bool escaped_char = false;
-    for (; pos_in_old < val.length(); ++pos_in_old) {
-        const char& c = val[pos_in_old];
-        if (c == '"' || c == '\\' || c == ' ') {
+    for (const char& c : val) {
+        if (char_requires_escaping(c)) {
             escaped_char = true;
             break;
         }
     }
-    if (!escaped_char)
-        return val;
 
-    size_t pos_in_new = 1;
-    string new_string(val.length() * 2 + 2, '\"');
-    for (pos_in_old = 0; pos_in_old < val.length(); ++pos_in_old) {
-        const char& c = val[pos_in_old];
-        if (c == '"' || c == '\\') {
-            new_string[pos_in_new++] = '\\';
-        }
-        new_string[pos_in_new++] = val[pos_in_old];
+    if (!escaped_char) {
+        return val;
     }
-    new_string.resize(pos_in_new + 1);
-    return new_string;
+
+    std::stringstream new_string;
+    new_string << '\"';
+    for (const char& c : val) {
+        if (char_requires_escaping(c)) {
+            new_string << '\\';
+        }
+        new_string << c;
+    }
+    new_string << '\"';
+
+    return new_string.str();
 }
 
 template <typename T>
-static void output_property_names(ostream& out, const string& indentation,
-                                  map<string, T> properties)
+inline void output_property_names(ostream& out, const string& indentation,
+                                  const map<string, T>& properties)
 {
     for (const auto& p : properties) {
         out << indentation << p.first << "\n";
@@ -58,53 +67,83 @@ static void output_property_names(ostream& out, const string& indentation,
 }
 
 template <typename T>
-static void output_property_values(ostream& out, const string& indentation,
-                                   map<string, T> properties)
+inline void output_property_values(ostream& out, const string& indentation,
+                                   const map<string, T>& properties)
 {
     for (const auto& p : properties) {
         out << indentation << local_to_string(p.second) << "\n";
     }
 }
 
-Block::~Block()
+template <typename T>
+void output_indexed_property_values(ostream& out,
+                                           const map<string, T>& properties,
+                                           unsigned int index)
 {
-    // TODO: check with valgrind whether some destructor is needed
+    for (const auto& p : properties) {
+        const auto& property = p.second;
+        if (property->isDefined(index)) {
+            out << ' ' << local_to_string(property->at(index));
+        } else {
+            out << " <>";
+        }
+    }
+}
+
+template <typename T>
+bool maps_indexed_props_equal(const T& lmap, const T& rmap)
+{
+    if (rmap.size() != lmap.size())
+        return false;
+    auto diff = std::mismatch(
+        lmap.begin(), lmap.end(), rmap.begin(),
+        [](decltype(*begin(lmap)) l, decltype(*begin(lmap)) r) {
+            return l.first == r.first && *(l.second) == *(r.second);
+        });
+    if (diff.first != lmap.end())
+        return false;
+    return true;
+}
 }
 
 void Block::write(ostream& out, unsigned int current_indentation) const
 {
 
     string root_indentation = string(current_indentation, ' ');
-    string indentation = string(current_indentation + 2, ' ');
+    current_indentation += 2;
+    string indentation = string(current_indentation, ' ');
+
+    const bool has_data = !m_bmap.empty() || !m_rmap.empty() ||
+                          !m_imap.empty() || !m_smap.empty();
 
     out << root_indentation << getName() << " {\n";
 
-    output_property_names(out, indentation, m_bmap);
-    output_property_names(out, indentation, m_rmap);
-    output_property_names(out, indentation, m_imap);
-    output_property_names(out, indentation, m_smap);
+    if (has_data) {
+        output_property_names(out, indentation, m_bmap);
+        output_property_names(out, indentation, m_rmap);
+        output_property_names(out, indentation, m_imap);
+        output_property_names(out, indentation, m_smap);
 
-    if (m_bmap.size() + m_rmap.size() + m_imap.size() + m_smap.size() > 0) {
         out << indentation + ":::\n";
-    }
 
-    output_property_values(out, indentation, m_bmap);
-    output_property_values(out, indentation, m_rmap);
-    output_property_values(out, indentation, m_imap);
-    output_property_values(out, indentation, m_smap);
+        output_property_values(out, indentation, m_bmap);
+        output_property_values(out, indentation, m_rmap);
+        output_property_values(out, indentation, m_imap);
+        output_property_values(out, indentation, m_smap);
+    }
 
     if (hasIndexedBlockData()) {
         const auto block_names = m_indexed_block_map->getBlockNames();
         for (const auto& name : block_names) {
             const auto& indexed_block =
                 m_indexed_block_map->getIndexedBlock(name);
-            indexed_block->write(out, current_indentation + 2);
+            indexed_block->write(out, current_indentation);
         }
     }
 
     for (const auto& p : m_sub_block) {
         const auto& sub_block = p.second;
-        sub_block->write(out, current_indentation + 2);
+        sub_block->write(out, current_indentation);
     }
 
     out << root_indentation << "}\n\n";
@@ -270,54 +309,36 @@ size_t IndexedBlock::size() const
     return count;
 }
 
-template <typename T>
-static void output_indexed_property_values(ostream& out,
-                                           map<string, T> properties,
-                                           unsigned int index)
-{
-    for (const auto& p : properties) {
-        const auto& property = p.second;
-        if (property->isDefined(index)) {
-            out << ' ' << local_to_string(property->at(index));
-        } else {
-            out << " <>";
-        }
-    }
-}
-
 void IndexedBlock::write(ostream& out, unsigned int current_indentation) const
 {
     string root_indentation = string(current_indentation, ' ');
     string indentation = string(current_indentation + 2, ' ');
-    const bool has_data =
-        m_bmap.size() + m_rmap.size() + m_imap.size() + m_smap.size() > 0;
+
+    const bool has_data = !m_bmap.empty() || !m_rmap.empty() ||
+                          !m_imap.empty() || !m_smap.empty();
 
     out << root_indentation << getName() << "[" << to_string((int) size())
         << "] {\n";
 
     if (has_data) {
         out << indentation + "# First column is Index #\n";
-    }
 
-    output_property_names(out, indentation, m_bmap);
-    output_property_names(out, indentation, m_rmap);
-    output_property_names(out, indentation, m_imap);
-    output_property_names(out, indentation, m_smap);
+        output_property_names(out, indentation, m_bmap);
+        output_property_names(out, indentation, m_rmap);
+        output_property_names(out, indentation, m_imap);
+        output_property_names(out, indentation, m_smap);
 
-    if (has_data) {
         out << indentation + ":::\n";
-    }
 
-    for (unsigned int i = 0; i < size(); ++i) {
-        out << indentation << i + 1;
-        output_indexed_property_values(out, m_bmap, i);
-        output_indexed_property_values(out, m_rmap, i);
-        output_indexed_property_values(out, m_imap, i);
-        output_indexed_property_values(out, m_smap, i);
-        out << endl;
-    }
+        for (unsigned int i = 0; i < size(); ++i) {
+            out << indentation << i + 1;
+            output_indexed_property_values(out, m_bmap, i);
+            output_indexed_property_values(out, m_rmap, i);
+            output_indexed_property_values(out, m_imap, i);
+            output_indexed_property_values(out, m_smap, i);
+            out << endl;
+        }
 
-    if (has_data) {
         out << indentation + ":::\n";
     }
 
@@ -364,21 +385,6 @@ operator==(const IndexedProperty<double>& rhs) const
         if ((float) abs(m_data[i] - rhs.m_data[i]) > tolerance)
             return false;
 
-    return true;
-}
-
-template <typename T>
-static bool maps_indexed_props_equal(const T& lmap, const T& rmap)
-{
-    if (rmap.size() != lmap.size())
-        return false;
-    auto diff = std::mismatch(
-        lmap.begin(), lmap.end(), rmap.begin(),
-        [](decltype(*begin(lmap)) l, decltype(*begin(lmap)) r) {
-            return l.first == r.first && *(l.second) == *(r.second);
-        });
-    if (diff.first != lmap.end())
-        return false;
     return true;
 }
 

--- a/MaeBlock.cpp
+++ b/MaeBlock.cpp
@@ -22,7 +22,7 @@ template <typename T> inline string local_to_string(T val)
 
 inline bool char_requires_escaping(char c)
 {
-    return c == '"' || c == '\\' || c == ' ';
+    return c == '"' || c == '\\';
 }
 
 string local_to_string(const string& val)
@@ -31,16 +31,17 @@ string local_to_string(const string& val)
         return R"("")";
     }
 
-    // Create new string big enough to escape every character and add quotes
-    bool escaped_char = false;
+    // Quotes are required if any character need escaping, or there are
+    // spaces in the string (spaces do not require escaping)
+    bool quotes_required = false;
     for (const char& c : val) {
-        if (char_requires_escaping(c)) {
-            escaped_char = true;
+        if (char_requires_escaping(c) || c == ' ') {
+            quotes_required = true;
             break;
         }
     }
 
-    if (!escaped_char) {
+    if (!quotes_required) {
         return val;
     }
 

--- a/MaeBlock.hpp
+++ b/MaeBlock.hpp
@@ -235,9 +235,9 @@ class EXPORT_MAEPARSER Block
         return get_property<std::string>(m_smap, name);
     }
 
-    void setStringProperty(const std::string& name, const std::string& value)
+    void setStringProperty(const std::string& name, std::string value)
     {
-        m_smap[name] = value;
+        m_smap[name] = std::move(value);
     }
 };
 

--- a/MaeBlock.hpp
+++ b/MaeBlock.hpp
@@ -363,11 +363,7 @@ inline void set_indexed_property(std::map<std::string, std::shared_ptr<T>>& map,
                                  std::shared_ptr<T> value)
 
 {
-    auto iter = map.find(name);
-    if (iter != map.end()) {
-        map.erase(iter);
-    }
-    map.insert(std::pair<std::string, std::shared_ptr<T>>(name, value));
+    map[name] = std::move(value);
 }
 
 class EXPORT_MAEPARSER IndexedBlock

--- a/MaeBlock.hpp
+++ b/MaeBlock.hpp
@@ -34,8 +34,10 @@ class IndexedBlock;
 class EXPORT_MAEPARSER IndexedBlockMapI
 {
   public:
-    virtual ~IndexedBlockMapI(){};
+    virtual ~IndexedBlockMapI() = default;
+
     virtual bool hasIndexedBlock(const std::string& name) const = 0;
+
     virtual std::shared_ptr<const IndexedBlock>
     getIndexedBlock(const std::string& name) const = 0;
 
@@ -109,7 +111,7 @@ class EXPORT_MAEPARSER BufferedIndexedBlockMap : public IndexedBlockMapI
 class EXPORT_MAEPARSER Block
 {
   private:
-    std::string m_name;
+    const std::string m_name;
 
     std::map<std::string, BoolProperty> m_bmap;
     std::map<std::string, double> m_rmap;
@@ -119,21 +121,20 @@ class EXPORT_MAEPARSER Block
     std::shared_ptr<IndexedBlockMapI> m_indexed_block_map;
 
     // Prevent copying.
-    Block(const Block&);
-    Block& operator=(const Block&);
+    Block(const Block&) = delete;
+    Block& operator=(const Block&) = delete;
 
   public:
     Block(std::string name)
-        : m_name(name), m_bmap(), m_rmap(), m_imap(), m_smap(),
+        : m_name(std::move(name)), m_bmap(), m_rmap(), m_imap(), m_smap(),
           m_indexed_block_map(nullptr)
     {
     }
 
-    ~Block();
-
     const std::string& getName() const { return m_name; }
 
     std::string toString() const;
+
     void write(std::ostream& out, unsigned int current_indentation = 0) const;
 
     void setIndexedBlockMap(std::shared_ptr<IndexedBlockMapI> indexed_block_map)
@@ -234,7 +235,7 @@ class EXPORT_MAEPARSER Block
         return get_property<std::string>(m_smap, name);
     }
 
-    void setStringProperty(const std::string& name, std::string value)
+    void setStringProperty(const std::string& name, const std::string& value)
     {
         m_smap[name] = value;
     }
@@ -247,8 +248,8 @@ template <typename T> class IndexedProperty
     boost::dynamic_bitset<>* m_is_null;
 
     // Prevent copying.
-    IndexedProperty<T>(const IndexedProperty<T>&);
-    IndexedProperty<T>& operator=(const IndexedProperty<T>&);
+    IndexedProperty<T>(const IndexedProperty<T>&) = delete;
+    IndexedProperty<T>& operator=(const IndexedProperty<T>&) = delete;
 
   public:
     typedef typename std::vector<T>::size_type size_type;
@@ -359,7 +360,7 @@ get_indexed_property(const std::map<std::string, std::shared_ptr<T>>& map,
 template <typename T>
 inline void set_indexed_property(std::map<std::string, std::shared_ptr<T>>& map,
                                  const std::string& name,
-                                 const std::shared_ptr<T> value)
+                                 std::shared_ptr<T> value)
 
 {
     auto iter = map.find(name);
@@ -380,29 +381,32 @@ class EXPORT_MAEPARSER IndexedBlock
     std::map<std::string, std::shared_ptr<IndexedStringProperty>> m_smap;
 
     // Prevent copying.
-    IndexedBlock(const IndexedBlock&);
-    IndexedBlock& operator=(const IndexedBlock&);
+    IndexedBlock(const IndexedBlock&) = delete;
+    IndexedBlock& operator=(const IndexedBlock&) = delete;
 
   public:
     /**
      * Create an indexed block.
      */
-    IndexedBlock(const std::string& name)
-        : m_name(name), m_bmap(), m_imap(), m_rmap(), m_smap()
+    IndexedBlock(std::string name)
+        : m_name(std::move(name)), m_bmap(), m_imap(), m_rmap(), m_smap()
     {
     }
 
     size_t size() const;
+
     const std::string& getName() const { return m_name; }
+
     std::string toString() const;
+
     void write(std::ostream& out, unsigned int current_indentation = 0) const;
+
     bool operator==(const IndexedBlock& rhs) const;
+
     bool operator!=(const IndexedBlock& rhs) const
     {
         return !(operator==(rhs));
     }
-
-    // Default destructor. ~IndexedBlock()
 
     template <typename T>
     void setProperty(const std::string& name,
@@ -420,7 +424,7 @@ class EXPORT_MAEPARSER IndexedBlock
     }
 
     void setBoolProperty(const std::string& name,
-                         const std::shared_ptr<IndexedBoolProperty> value)
+                         std::shared_ptr<IndexedBoolProperty> value)
     {
         set_indexed_property<IndexedBoolProperty>(m_bmap, name, value);
     }
@@ -437,7 +441,7 @@ class EXPORT_MAEPARSER IndexedBlock
     }
 
     void setIntProperty(const std::string& name,
-                        const std::shared_ptr<IndexedIntProperty> value)
+                        std::shared_ptr<IndexedIntProperty> value)
     {
         set_indexed_property<IndexedIntProperty>(m_imap, name, value);
     }
@@ -454,7 +458,7 @@ class EXPORT_MAEPARSER IndexedBlock
     }
 
     void setRealProperty(const std::string& name,
-                         const std::shared_ptr<IndexedRealProperty> value)
+                         std::shared_ptr<IndexedRealProperty> value)
     {
         set_indexed_property<IndexedRealProperty>(m_rmap, name, value);
     }
@@ -471,7 +475,7 @@ class EXPORT_MAEPARSER IndexedBlock
     }
 
     void setStringProperty(const std::string& name,
-                           const std::shared_ptr<IndexedStringProperty> value)
+                           std::shared_ptr<IndexedStringProperty> value)
     {
         set_indexed_property<IndexedStringProperty>(m_smap, name, value);
     }

--- a/test/MaeBlockTest.cpp
+++ b/test/MaeBlockTest.cpp
@@ -35,7 +35,7 @@ BOOST_AUTO_TEST_CASE(maeBlock)
     BOOST_REQUIRE_THROW(b.getBoolProperty("b"), std::out_of_range);
 
     const std::vector<std::string> strings = {"Regular", "Spaced String"};
-    for (const auto value : strings) {
+    for (const auto& value : strings) {
         b.setStringProperty("a", value);
         BOOST_REQUIRE(b.hasStringProperty("a"));
         BOOST_REQUIRE(!b.hasStringProperty("b"));


### PR DESCRIPTION
Some refactorings I did on this:

- Moving static functions into an anonymous namespace at the top of the file.
- Clear unrequired destructors.
- Refactor `local_to_string()` and extract `char_requires_escaping()` -- was this a bug? (also, don't we replace this with an underscore?) we missed the space character in the actual escapation.
- Made some arguments `const &`.
- Small refactoring in `Block::write()` and `IndexedBlock::write()`.
- Delete copy constructors and assignment operators.
- Use `move` with block names. Also made `Block::m_name` a `const`.