### PR TITLE
Added stream opening checks to Reader & Writer

### DIFF
--- a/Reader.cpp
+++ b/Reader.cpp
@@ -6,6 +6,7 @@
 #include <boost/iostreams/filtering_stream.hpp>
 
 #include <fstream>
+#include <sstream>
 #include <iostream>
 
 using boost::algorithm::ends_with;
@@ -40,6 +41,12 @@ Reader::Reader(const std::string& fname, size_t buffer_size)
     } else {
         auto* file_stream = new std::ifstream(fname, ios_mode);
         stream.reset(static_cast<std::istream*>(file_stream));
+    }
+
+    if(stream->fail()) {
+        std::stringstream ss;
+        ss << "Failed to open file \"" << fname << "\" for reading operation.";
+        throw std::runtime_error(ss.str());
     }
 
     m_mae_parser.reset(new MaeParser(stream, buffer_size));

--- a/Writer.cpp
+++ b/Writer.cpp
@@ -6,6 +6,7 @@
 #include <boost/iostreams/device/file.hpp>
 
 #include <fstream>
+#include <sstream>
 #include <iostream>
 
 #include "MaeBlock.hpp"
@@ -37,6 +38,12 @@ Writer::Writer(const std::string& fname)
     } else {
         auto* file_stream = new ofstream(fname, ios_mode);
         m_out.reset(static_cast<ostream*>(file_stream));
+    }
+
+    if(m_out->fail()) {
+        std::stringstream ss;
+        ss << "Failed to open file \"" << fname << "\" for writing operation.";
+        throw std::runtime_error(ss.str());
     }
 
     write_opening_block();

--- a/test/ReaderTest.cpp
+++ b/test/ReaderTest.cpp
@@ -9,6 +9,7 @@
 #include "MaeBlock.hpp"
 #include "MaeConstants.hpp"
 #include "Reader.hpp"
+#include "TestCommon.hpp"
 
 using namespace schrodinger::mae;
 using std::shared_ptr;
@@ -314,6 +315,15 @@ BOOST_AUTO_TEST_CASE(QuotedStringTest)
     BOOST_REQUIRE_EQUAL(atom_names->at(0), R"(Does p " \this work)");
 
     fclose(f);
+}
+
+BOOST_AUTO_TEST_CASE(TestReadNonExistingFile)
+{
+    // This file should not exist!
+    CheckExceptionMsg<std::runtime_error> check_msg("Failed to open file \"non_existing_file.mae\" for reading operation");
+
+    BOOST_CHECK_EXCEPTION(Reader r("non_existing_file.mae"), std::runtime_error,
+                          check_msg);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/TestCommon.hpp
+++ b/test/TestCommon.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <string>
+#include <sstream>
+
+#include <boost/test/unit_test.hpp>
+
+template <class T> class CheckExceptionMsg
+{
+  public:
+    CheckExceptionMsg(std::string msg)
+        : m_expected(std::move(msg)), m_match(false)
+    {
+    }
+
+    ~CheckExceptionMsg()
+    {
+        // This message should be printer after BOOST_REQUIRE_EXCEPTION's
+        std::stringstream ss;
+        ss << '\"' << m_expected << "\" not found in \"" << m_message << '\"';
+
+        BOOST_CHECK_MESSAGE(m_match, ss.str());
+    }
+
+    bool operator()(const T& exc)
+    {
+        m_message = exc.what();
+        m_match = m_message.find(m_expected) != std::string::npos;
+
+        return m_match;
+    }
+
+  private:
+    const std::string m_expected;
+    std::string m_message;
+    bool m_match;
+};

--- a/test/WriterTest.cpp
+++ b/test/WriterTest.cpp
@@ -7,6 +7,7 @@
 #include "MaeConstants.hpp"
 #include "Reader.hpp"
 #include "Writer.hpp"
+#include "TestCommon.hpp"
 
 #define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
@@ -80,6 +81,14 @@ BOOST_AUTO_TEST_CASE(Writer1)
     while ((b = output_r.next(CT_BLOCK)) != nullptr) {
         BOOST_CHECK(*b == *(input[input_num++]));
     }
+}
+
+BOOST_AUTO_TEST_CASE(TestWriteNonAccessiblePath)
+{
+    // This path should not exist/be accesible!
+    CheckExceptionMsg<std::runtime_error> check_msg("Failed to open file \"/non/accessible/path/file.mae\" for writing operation");
+
+    BOOST_CHECK_EXCEPTION(Writer w("/non/accessible/path/file.mae")    , std::runtime_error, check_msg);
 }
 
 /*


### PR DESCRIPTION
Addresses #42 

By checking the stream state in the file name constructors of the Reader and Writer classes we can detect problems like file/path existence and permissions before actually trying to read/write to files. This an early way of differentiating these problems from actual reading/writing errors (i.e. reading a malformed file).
