### PR TITLE
maeparser does not support numbers in property author names

### DIFF
--- a/MaeParser.cpp
+++ b/MaeParser.cpp
@@ -448,21 +448,17 @@ bad_format:
 bool property_key_author_name(Buffer& buffer, char*& save)
 {
     while (buffer.current < buffer.end || buffer.load(save)) {
-        switch (*buffer.current) {
-        case '_':
+        if (*buffer.current == '_') {
             ++buffer.current;
-            goto name;
-        default:
-            if (!((*buffer.current >= 'a' && *buffer.current <= 'z') ||
-                  (*buffer.current >= 'A' && *buffer.current <= 'Z') ||
-                  (*buffer.current >= '0' && *buffer.current <= '9'))) {
-                return false;
-            }
+            break;
+        } else if (!((*buffer.current >= 'a' && *buffer.current <= 'z') ||
+                     (*buffer.current >= 'A' && *buffer.current <= 'Z') ||
+                     (*buffer.current >= '0' && *buffer.current <= '9'))) {
+            return false;
         }
         ++buffer.current;
     }
 
-name:
     char* start = buffer.current;
     while (buffer.current < buffer.end || buffer.load(save)) {
         switch (*buffer.current) {

--- a/MaeParser.cpp
+++ b/MaeParser.cpp
@@ -454,7 +454,8 @@ bool property_key_author_name(Buffer& buffer, char*& save)
             goto name;
         default:
             if (!((*buffer.current >= 'a' && *buffer.current <= 'z') ||
-                  (*buffer.current >= 'A' && *buffer.current <= 'Z'))) {
+                  (*buffer.current >= 'A' && *buffer.current <= 'Z') ||
+                  (*buffer.current >= '0' && *buffer.current <= '9'))) {
                 return false;
             }
         }


### PR DESCRIPTION
Forwarded from [RDKit issue #2579](https://github.com/rdkit/rdkit/issues/2579).

Adding numbers to the set of allowed characters fixes the issue.