### PR TITLE
Remove "sudo:false" and automated apt workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
-sudo: false
-
 language: cpp
 
-#Travis' automated apt seems to be broken in bionic, so we need a workaround
 before_script:
-  - "if [ \"${DIST}\" == \"bionic\" ]; then sudo apt update && sudo apt install -y gcc-7 g++-7 libboost1.62-all-dev valgrind; fi"
   - mkdir build
   - cd build
   - cmake .. -DMAEPARSER_RIGOROUS_BUILD=ON  -DCMAKE_BUILD_TYPE=Debug
@@ -18,7 +14,7 @@ matrix:
   include:
     - os: linux
       dist: trusty
-      env: CC="gcc-4.8" CXX="g++-4.8" DIST="trusty"
+      env: CC="gcc-4.8" CXX="g++-4.8"
       addons:
         apt:
           packages:
@@ -29,7 +25,7 @@ matrix:
 
     - os: linux
       dist: xenial
-      env: CC="gcc-5" CXX="g++-5" DIST="xenial"
+      env: CC="gcc-5" CXX="g++-5"
       addons:
         apt:
           packages:
@@ -40,5 +36,12 @@ matrix:
 
     - os: linux
       dist: bionic
-      env: CC="gcc-7" CXX="g++-7" DIST="bionic"
+      env: CC="gcc-7" CXX="g++-7"
+      addons:
+        apt:
+          packages:
+            - gcc-7
+            - g++-7
+            - libboost1.62-all-dev
+            - valgrind
 


### PR DESCRIPTION
`sudo: false` is long deprecated, and should be removed, and it seems that the workaround is no longer required (although the "unable to resolve host" are still there): either removing the `sudo` fixes it, or Travis fixed it since I last tried.