### PR TITLE
Provide eof() methods to check end of data

### DIFF
--- a/MaeParser.cpp
+++ b/MaeParser.cpp
@@ -405,6 +405,12 @@ std::shared_ptr<std::string> MaeParser::property()
     return property_key(m_buffer);
 }
 
+bool MaeParser::eof()
+{
+    whitespace();
+    return !m_buffer.load();
+}
+
 std::shared_ptr<std::string> property_key(Buffer& buffer)
 {
     if (!buffer.load()) {

--- a/MaeParser.hpp
+++ b/MaeParser.hpp
@@ -323,6 +323,11 @@ class EXPORT_MAEPARSER MaeParser
      * Read (and throw away) any whitespace.
      */
     void whitespace() { schrodinger::mae::whitespace(m_buffer); }
+
+    /**
+     *  Check if the parser reached the end of the data.
+     */
+    bool eof();
 };
 
 class EXPORT_MAEPARSER DirectMaeParser : public MaeParser

--- a/Reader.cpp
+++ b/Reader.cpp
@@ -6,8 +6,8 @@
 #include <boost/iostreams/filtering_stream.hpp>
 
 #include <fstream>
-#include <sstream>
 #include <iostream>
+#include <sstream>
 
 using boost::algorithm::ends_with;
 using boost::iostreams::file_source;
@@ -43,7 +43,7 @@ Reader::Reader(const std::string& fname, size_t buffer_size)
         stream.reset(static_cast<std::istream*>(file_stream));
     }
 
-    if(stream->fail()) {
+    if (stream->fail()) {
         std::stringstream ss;
         ss << "Failed to open file \"" << fname << "\" for reading operation.";
         throw std::runtime_error(ss.str());
@@ -65,5 +65,11 @@ std::shared_ptr<Block> Reader::next(const std::string& outer_block_name)
     } while (block != nullptr && block->getName() != outer_block_name);
     return block;
 }
+
+bool Reader::eof()
+{
+    return m_mae_parser->eof();
+}
+
 } // namespace mae
 } // namespace schrodinger

--- a/Reader.hpp
+++ b/Reader.hpp
@@ -35,6 +35,11 @@ class EXPORT_MAEPARSER Reader
     Reader(std::shared_ptr<MaeParser> mae_parser);
 
     std::shared_ptr<Block> next(const std::string& outer_block_name);
+
+    /**
+     *  Check if the parser reached the end of the data.
+     */
+    bool eof();
 };
 
 } // namespace mae

--- a/test/ReaderTest.cpp
+++ b/test/ReaderTest.cpp
@@ -326,4 +326,16 @@ BOOST_AUTO_TEST_CASE(TestReadNonExistingFile)
                           check_msg);
 }
 
+BOOST_AUTO_TEST_CASE(TestReaderEof)
+{
+    Reader r(uncompressed_sample);
+
+    size_t count = 0;
+    while (!r.eof()) {
+       BOOST_CHECK_NE(r.next(CT_BLOCK), nullptr);
+        ++count;
+    }
+    BOOST_CHECK_EQUAL(count, 3u);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/ReaderTest.cpp
+++ b/test/ReaderTest.cpp
@@ -332,7 +332,7 @@ BOOST_AUTO_TEST_CASE(TestReaderEof)
 
     size_t count = 0;
     while (!r.eof()) {
-       BOOST_CHECK_NE(r.next(CT_BLOCK), nullptr);
+       BOOST_CHECK(r.next(CT_BLOCK) != nullptr);
         ++count;
     }
     BOOST_CHECK_EQUAL(count, 3u);


### PR DESCRIPTION
The idea is to provide a means of checking if Reader or MaeParser objects have reached the end of the available data without throwing exceptions or attempting to read more "real" data (whitespace is ok).
