### PR TITLE
Properly export getProperty() methods

### DIFF
--- a/MaeBlock.cpp
+++ b/MaeBlock.cpp
@@ -78,8 +78,8 @@ inline void output_property_values(ostream& out, const string& indentation,
 
 template <typename T>
 void output_indexed_property_values(ostream& out,
-                                           const map<string, T>& properties,
-                                           unsigned int index)
+                                    const map<string, T>& properties,
+                                    unsigned int index)
 {
     for (const auto& p : properties) {
         const auto& property = p.second;
@@ -105,7 +105,7 @@ bool maps_indexed_props_equal(const T& lmap, const T& rmap)
         return false;
     return true;
 }
-}
+} // namespace
 
 void Block::write(ostream& out, unsigned int current_indentation) const
 {
@@ -170,25 +170,28 @@ shared_ptr<const IndexedBlock> Block::getIndexedBlock(const string& name)
 }
 
 template <>
-const std::map<std::string, BoolProperty>&
+EXPORT_MAEPARSER const std::map<std::string, BoolProperty>&
 Block::getProperties<BoolProperty>() const
 {
     return m_bmap;
 }
 
-template <> const std::map<std::string, int>& Block::getProperties<int>() const
+template <>
+EXPORT_MAEPARSER const std::map<std::string, int>&
+Block::getProperties<int>() const
 {
     return m_imap;
 }
 
 template <>
-const std::map<std::string, double>& Block::getProperties<double>() const
+EXPORT_MAEPARSER const std::map<std::string, double>&
+Block::getProperties<double>() const
 {
     return m_rmap;
 }
 
 template <>
-const std::map<std::string, std::string>&
+EXPORT_MAEPARSER const std::map<std::string, std::string>&
 Block::getProperties<std::string>() const
 {
     return m_smap;
@@ -429,29 +432,33 @@ bool IndexedBlock::operator==(const IndexedBlock& rhs) const
 }
 
 template <>
-const std::map<std::string, std::shared_ptr<IndexedProperty<BoolProperty>>>&
-IndexedBlock::getProperties() const
+EXPORT_MAEPARSER const
+    std::map<std::string, std::shared_ptr<IndexedProperty<BoolProperty>>>&
+    IndexedBlock::getProperties() const
 {
     return m_bmap;
 }
 
 template <>
-const std::map<std::string, std::shared_ptr<IndexedProperty<int>>>&
-IndexedBlock::getProperties() const
+EXPORT_MAEPARSER const
+    std::map<std::string, std::shared_ptr<IndexedProperty<int>>>&
+    IndexedBlock::getProperties() const
 {
     return m_imap;
 }
 
 template <>
-const std::map<std::string, std::shared_ptr<IndexedProperty<double>>>&
-IndexedBlock::getProperties() const
+EXPORT_MAEPARSER const
+    std::map<std::string, std::shared_ptr<IndexedProperty<double>>>&
+    IndexedBlock::getProperties() const
 {
     return m_rmap;
 }
 
 template <>
-const std::map<std::string, std::shared_ptr<IndexedProperty<std::string>>>&
-IndexedBlock::getProperties() const
+EXPORT_MAEPARSER const
+    std::map<std::string, std::shared_ptr<IndexedProperty<std::string>>>&
+    IndexedBlock::getProperties() const
 {
     return m_smap;
 }

--- a/MaeBlock.cpp
+++ b/MaeBlock.cpp
@@ -169,34 +169,6 @@ shared_ptr<const IndexedBlock> Block::getIndexedBlock(const string& name)
         m_indexed_block_map->getIndexedBlock(name));
 }
 
-template <>
-EXPORT_MAEPARSER const std::map<std::string, BoolProperty>&
-Block::getProperties<BoolProperty>() const
-{
-    return m_bmap;
-}
-
-template <>
-EXPORT_MAEPARSER const std::map<std::string, int>&
-Block::getProperties<int>() const
-{
-    return m_imap;
-}
-
-template <>
-EXPORT_MAEPARSER const std::map<std::string, double>&
-Block::getProperties<double>() const
-{
-    return m_rmap;
-}
-
-template <>
-EXPORT_MAEPARSER const std::map<std::string, std::string>&
-Block::getProperties<std::string>() const
-{
-    return m_smap;
-}
-
 bool real_map_equal(const map<string, double>& rmap1,
                     const map<string, double>& rmap2)
 {
@@ -429,38 +401,6 @@ bool IndexedBlock::operator==(const IndexedBlock& rhs) const
         return false;
 
     return true;
-}
-
-template <>
-EXPORT_MAEPARSER const
-    std::map<std::string, std::shared_ptr<IndexedProperty<BoolProperty>>>&
-    IndexedBlock::getProperties() const
-{
-    return m_bmap;
-}
-
-template <>
-EXPORT_MAEPARSER const
-    std::map<std::string, std::shared_ptr<IndexedProperty<int>>>&
-    IndexedBlock::getProperties() const
-{
-    return m_imap;
-}
-
-template <>
-EXPORT_MAEPARSER const
-    std::map<std::string, std::shared_ptr<IndexedProperty<double>>>&
-    IndexedBlock::getProperties() const
-{
-    return m_rmap;
-}
-
-template <>
-EXPORT_MAEPARSER const
-    std::map<std::string, std::shared_ptr<IndexedProperty<std::string>>>&
-    IndexedBlock::getProperties() const
-{
-    return m_smap;
 }
 
 } // namespace mae

--- a/MaeBlock.hpp
+++ b/MaeBlock.hpp
@@ -340,8 +340,8 @@ template <typename T> class IndexedProperty
         }
     }
 
-    const std::vector<T>& data() const {return m_data;}
-    const boost::dynamic_bitset<>* nullIndices() const {return m_is_null;}
+    const std::vector<T>& data() const { return m_data; }
+    const boost::dynamic_bitset<>* nullIndices() const { return m_is_null; }
 };
 
 typedef IndexedProperty<double> IndexedRealProperty;
@@ -485,6 +485,64 @@ class EXPORT_MAEPARSER IndexedBlock
     const std::map<std::string, std::shared_ptr<IndexedProperty<T>>>&
     getProperties() const;
 };
+
+// Template specializations
+
+template <>
+inline const std::map<std::string, BoolProperty>&
+Block::getProperties<BoolProperty>() const
+{
+    return m_bmap;
+}
+
+template <>
+inline const std::map<std::string, int>& Block::getProperties<int>() const
+{
+    return m_imap;
+}
+
+template <>
+inline const std::map<std::string, double>& Block::getProperties<double>() const
+{
+    return m_rmap;
+}
+
+template <>
+inline const std::map<std::string, std::string>&
+Block::getProperties<std::string>() const
+{
+    return m_smap;
+}
+
+template <>
+inline const std::map<std::string,
+                      std::shared_ptr<IndexedProperty<BoolProperty>>>&
+IndexedBlock::getProperties() const
+{
+    return m_bmap;
+}
+
+template <>
+inline const std::map<std::string, std::shared_ptr<IndexedProperty<int>>>&
+IndexedBlock::getProperties() const
+{
+    return m_imap;
+}
+
+template <>
+inline const std::map<std::string, std::shared_ptr<IndexedProperty<double>>>&
+IndexedBlock::getProperties() const
+{
+    return m_rmap;
+}
+
+template <>
+inline const std::map<std::string,
+                      std::shared_ptr<IndexedProperty<std::string>>>&
+IndexedBlock::getProperties() const
+{
+    return m_smap;
+}
 
 } // namespace mae
 } // namespace schrodinger

--- a/MaeBlock.hpp
+++ b/MaeBlock.hpp
@@ -241,13 +241,6 @@ class EXPORT_MAEPARSER Block
     }
 
     template <typename T> const std::map<std::string, T>& getProperties() const;
-#ifdef WIN32
-    template <>
-    const std::map<std::string, BoolProperty>& getProperties() const;
-    template <> const std::map<std::string, int>& getProperties() const;
-    template <> const std::map<std::string, double>& getProperties() const;
-    template <> const std::map<std::string, std::string>& getProperties() const;
-#endif
 };
 
 template <typename T> class IndexedProperty
@@ -491,20 +484,6 @@ class EXPORT_MAEPARSER IndexedBlock
     template <typename T>
     const std::map<std::string, std::shared_ptr<IndexedProperty<T>>>&
     getProperties() const;
-#ifdef WIN32
-    template <>
-    const std::map<std::string, std::shared_ptr<IndexedProperty<BoolProperty>>>&
-    getProperties() const;
-    template <>
-    const std::map<std::string, std::shared_ptr<IndexedProperty<int>>>&
-    getProperties() const;
-    template <>
-    const std::map<std::string, std::shared_ptr<IndexedProperty<double>>>&
-    getProperties() const;
-    template <>
-    const std::map<std::string, std::shared_ptr<IndexedProperty<std::string>>>&
-    getProperties() const;
-#endif
 };
 
 } // namespace mae


### PR DESCRIPTION
Fix exports for `Block::getProperties()` and `IndexedBlock::getProperties()` in windows.