### PR TITLE
Make test path relative and allow to disable the test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 3.5)
 project(maeparser)
 
 option(MAEPARSER_RIGOROUS_BUILD "Abort the build if the compiler issues any warnings" OFF )
+option(MAEPARSER_BUILD_TESTS "Whether test executables should be built" ON)
 
 if(MSVC)
     # C4251 disables warnings for export STL containers as arguments (returning a vector of things)
@@ -44,17 +45,20 @@ INSTALL(EXPORT maeparser-targets
     FILE ${PROJECT_NAME}-config.cmake
     DESTINATION lib/cmake)
 
+install(FILES Buffer.hpp MaeBlock.hpp  MaeParserConfig.hpp  MaeParser.hpp  Reader.hpp MaeConstants.hpp
+        DESTINATION include/maeparser)
+
 target_compile_definitions(maeparser PRIVATE IN_MAEPARSER)
 
 set_property(TARGET maeparser PROPERTY CXX_VISIBILITY_PRESET "hidden")
 
-set(MEMORYCHECK_COMMAND_OPTIONS "${MEMORYCHECK_COMMAND_OPTIONS} --tool=memcheck \
-        --time-stamp=yes --num-callers=20 --gen-suppressions=all --leak-check=full \
-        --show-reachable=yes --trace-children=yes --error-exitcode=29")
+# Tests
+if (MAEPARSER_BUILD_TESTS)
+    set(MEMORYCHECK_COMMAND_OPTIONS "${MEMORYCHECK_COMMAND_OPTIONS} --tool=memcheck \
+            --time-stamp=yes --num-callers=20 --gen-suppressions=all --leak-check=full \
+            --show-reachable=yes --trace-children=yes --error-exitcode=29")
 
-include(CTest)
-add_subdirectory(test)
-
-install(FILES Buffer.hpp MaeBlock.hpp  MaeParserConfig.hpp  MaeParser.hpp  Reader.hpp MaeConstants.hpp
-        DESTINATION include/maeparser)
+    include(CTest)
+    add_subdirectory(test)
+endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,11 +8,11 @@ target_link_libraries(unittest maeparser Boost::unit_test_framework Boost::files
 get_filename_component(TEST_SAMPLES_PATH ${CMAKE_CURRENT_SOURCE_DIR} ABSOLUTE)
 target_compile_definitions(unittest PRIVATE "TEST_SAMPLES_PATH=\"${TEST_SAMPLES_PATH}\"")
 
-add_test(NAME unittest COMMAND ${CMAKE_BINARY_DIR}/test/unittest
-         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/test)
+add_test(NAME unittest COMMAND ${CMAKE_CURRENT_BINARY_DIR}/unittest
+         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 if(MSVC)
     add_custom_command(TARGET unittest POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different
-    "${PROJECT_BINARY_DIR}/\$\(Configuration\)/maeparser.dll" "${CMAKE_BINARY_DIR}/test/\$\(Configuration\)/maeparser.dll")
+    "${PROJECT_BINARY_DIR}/\$\(Configuration\)/maeparser.dll" "${CMAKE_CURRENT_BINARY_DIR}/\$\(Configuration\)/maeparser.dll")
 endif(MSVC)
 


### PR DESCRIPTION
This allows the test file to run correctly when maeparser is included from another CMake project. Also, it is possible to disable building the tests.

Not getting this path right was a problem if we want to include Maeparser from other CMake projects using the `add_subdirectory()` command: Maeparser would be build (assuming all the setup is correct), but the test would always fail, as there was no way to disable it, and `ctest` would get the wrong patch, since it expects it to live at the main project's directory.

(This is required for https://github.com/schrodinger/coordgenlibs/pull/41, which will stay as a draft until this and some other quirks are resolved)