### PR TITLE
Use a GLOB to find and install all headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,8 +45,8 @@ INSTALL(EXPORT maeparser-targets
     FILE ${PROJECT_NAME}-config.cmake
     DESTINATION lib/cmake)
 
-install(FILES Buffer.hpp MaeBlock.hpp MaeConstants.hpp MaeParser.hpp MaeParserConfig.hpp Reader.hpp Writer.hpp
-        DESTINATION include/maeparser)
+file(GLOB mae_headers "*.hpp")
+install(FILES ${mae_headers} DESTINATION include/maeparser)
 
 target_compile_definitions(maeparser PRIVATE IN_MAEPARSER)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ INSTALL(EXPORT maeparser-targets
     FILE ${PROJECT_NAME}-config.cmake
     DESTINATION lib/cmake)
 
-install(FILES Buffer.hpp MaeBlock.hpp  MaeParserConfig.hpp  MaeParser.hpp  Reader.hpp MaeConstants.hpp
+install(FILES Buffer.hpp MaeBlock.hpp MaeConstants.hpp MaeParser.hpp MaeParserConfig.hpp Reader.hpp Writer.hpp
         DESTINATION include/maeparser)
 
 target_compile_definitions(maeparser PRIVATE IN_MAEPARSER)


### PR DESCRIPTION
Writer.hpp was not being installed with the rest of the headers.

Using a GLOB to find all hpp headers ensures that all of them will be installed, even if more headers are added later (as long as all of them have the hpp extension)