### PR TITLE
Allow static builds

### DIFF
--- a/.azure-pipelines/linux_build.yml
+++ b/.azure-pipelines/linux_build.yml
@@ -1,39 +1,40 @@
 steps:
-- bash: |
-    source ${CONDA}/etc/profile.d/conda.sh
-    sudo chown -R ${USER} ${CONDA}
-    conda config --set always_yes yes --set changeps1 no
-    conda update -q conda
-    conda info -a
-    conda create --name maeparser_build $(compiler) cmake \
-        boost-cpp=$(boost_version) boost=$(boost_version) \
-        libboost=$(boost_version)
-  displayName: Setup build environment
-- bash: |
-    source ${CONDA}/etc/profile.d/conda.sh
-    conda activate maeparser_build
-    mkdir build && cd build && \
-    cmake .. \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DMAEPARSER_RIGOROUS_BUILD=ON \
-    -DBoost_NO_SYSTEM_PATHS=ON \
-    -DCMAKE_INCLUDE_PATH="${CONDA_PREFIX}/include" \
-    -DCMAKE_LIBRARY_PATH="${CONDA_PREFIX}/lib"
-  displayName: Configure build (Run CMake)
-- bash: |
-    source ${CONDA}/etc/profile.d/conda.sh
-    conda activate maeparser_build
-    cd build
-    make -j $( $(number_of_cores) )
-  displayName: Build
-- bash: |
-    source ${CONDA}/etc/profile.d/conda.sh
-    conda activate maeparser_build
-    cd build
-    ctest -j $( $(number_of_cores) ) --output-on-failure -T Test
-  displayName: Run tests
-- task: PublishTestResults@2
-  inputs:
-    testResultsFormat: 'CTest'
-    testResultsFiles: 'build/Testing/*/Test.xml'
-    testRunTitle: $(system.phasedisplayname) CTest Test Run
+  - bash: |
+      source ${CONDA}/etc/profile.d/conda.sh
+      sudo chown -R ${USER} ${CONDA}
+      conda config --set always_yes yes --set changeps1 no
+      conda update -q conda
+      conda info -a
+      conda create --name maeparser_build $(compiler) cmake \
+          boost-cpp=$(boost_version) boost=$(boost_version) \
+          libboost=$(boost_version)
+    displayName: Setup build environment
+  - bash: |
+      source ${CONDA}/etc/profile.d/conda.sh
+      conda activate maeparser_build
+      mkdir build && cd build && \
+      cmake .. \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DMAEPARSER_RIGOROUS_BUILD=ON \
+      -DBoost_NO_SYSTEM_PATHS=ON \
+      -DCMAKE_INCLUDE_PATH="${CONDA_PREFIX}/include" \
+      -DCMAKE_LIBRARY_PATH="${CONDA_PREFIX}/lib" \
+      -DMAEPARSER_BUILD_SHARED_LIBS=$(shared_lib)
+    displayName: Configure build (Run CMake)
+  - bash: |
+      source ${CONDA}/etc/profile.d/conda.sh
+      conda activate maeparser_build
+      cd build
+      make -j $( $(number_of_cores) )
+    displayName: Build
+  - bash: |
+      source ${CONDA}/etc/profile.d/conda.sh
+      conda activate maeparser_build
+      cd build
+      ctest -j $( $(number_of_cores) ) --output-on-failure -T Test
+    displayName: Run tests
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: "CTest"
+      testResultsFiles: "build/Testing/*/Test.xml"
+      testRunTitle: $(system.phasedisplayname) CTest Test Run

--- a/.azure-pipelines/mac_build.yml
+++ b/.azure-pipelines/mac_build.yml
@@ -1,59 +1,60 @@
 steps:
-- bash: |
-    wget https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX$(target_platform).sdk.tar.xz
-    tar Jxvf MacOSX$(target_platform).sdk.tar.xz
-  displayName: Install MacOSX $(target_platform) SDK
-- script: |
-    echo "Removing homebrew from Azure to avoid conflicts."
-    curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
-    chmod +x ~/uninstall_homebrew
-    ~/uninstall_homebrew -fq
-    rm ~/uninstall_homebrew
-  displayName: Remove homebrew
-- bash: |
-    source ${CONDA}/etc/profile.d/conda.sh
-    sudo chown -R ${USER} ${CONDA}
-    echo -e "backend: TkAgg\n" > $HOME/.matplotlib/matplotlibrc
-    conda config --set always_yes yes --set changeps1 no
-    conda update -q conda
-    conda create --name maeparser_build $(compiler) cmake \
-        boost-cpp=$(boost_version) boost=$(boost_version) \
-        py-boost=$(boost_version) libboost=$(boost_version)
-  displayName: Setup build environment
-- bash: |
-    source ${CONDA}/etc/profile.d/conda.sh
-    conda activate maeparser_build
-    export SDKROOT="$(pwd)/MacOSX$(target_platform).sdk/"
-    export CONDA_BUILD_SYSROOT=${SDKROOT}
-    mkdir build && cd build && \
-    cmake .. \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DMAEPARSER_RIGOROUS_BUILD=ON \
-    -DBoost_NO_SYSTEM_PATHS=ON \
-    -DCMAKE_OSX_SYSROOT=${SDKROOT} \
-    -DCMAKE_OSX_DEPLOYMENT_TARGET=$(target_platform) \
-    -DCMAKE_INCLUDE_PATH="${CONDA_PREFIX}/include" \
-    -DCMAKE_LIBRARY_PATH="${CONDA_PREFIX}/lib"
-  displayName: Configure build (Run CMake)
-- bash: |
-    source ${CONDA}/etc/profile.d/conda.sh
-    conda activate maeparser_build
-    export SDKROOT="$(pwd)/MacOSX$(target_platform).sdk/"
-    export CONDA_BUILD_SYSROOT=${SDKROOT}
-    cd build
-    make -j $( $(number_of_cores) )
-  displayName: Build
-- bash: |
-    source ${CONDA}/etc/profile.d/conda.sh
-    conda activate maeparser_build
-    export DYLD_FALLBACK_LIBRARY_PATH=${CONDA_PREFIX}/lib:${DYLD_FALLBACK_LIBRARY_PATH}
-    export SDKROOT="$(pwd)/MacOSX$(target_platform).sdk/"
-    export CONDA_BUILD_SYSROOT=${SDKROOT}
-    cd build
-    ctest -j $( $(number_of_cores) ) --output-on-failure -T Test
-  displayName: Run tests
-- task: PublishTestResults@2
-  inputs:
-    testResultsFormat: 'CTest'
-    testResultsFiles: 'build/Testing/*/Test.xml'
-    testRunTitle: $(system.phasedisplayname) CTest Test Run
+  - bash: |
+      wget https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX$(target_platform).sdk.tar.xz
+      tar Jxvf MacOSX$(target_platform).sdk.tar.xz
+    displayName: Install MacOSX $(target_platform) SDK
+  - script: |
+      echo "Removing homebrew from Azure to avoid conflicts."
+      curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
+      chmod +x ~/uninstall_homebrew
+      ~/uninstall_homebrew -fq
+      rm ~/uninstall_homebrew
+    displayName: Remove homebrew
+  - bash: |
+      source ${CONDA}/etc/profile.d/conda.sh
+      sudo chown -R ${USER} ${CONDA}
+      echo -e "backend: TkAgg\n" > $HOME/.matplotlib/matplotlibrc
+      conda config --set always_yes yes --set changeps1 no
+      conda update -q conda
+      conda create --name maeparser_build $(compiler) cmake \
+          boost-cpp=$(boost_version) boost=$(boost_version) \
+          py-boost=$(boost_version) libboost=$(boost_version)
+    displayName: Setup build environment
+  - bash: |
+      source ${CONDA}/etc/profile.d/conda.sh
+      conda activate maeparser_build
+      export SDKROOT="$(pwd)/MacOSX$(target_platform).sdk/"
+      export CONDA_BUILD_SYSROOT=${SDKROOT}
+      mkdir build && cd build && \
+      cmake .. \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DMAEPARSER_RIGOROUS_BUILD=ON \
+      -DBoost_NO_SYSTEM_PATHS=ON \
+      -DCMAKE_OSX_SYSROOT=${SDKROOT} \
+      -DCMAKE_OSX_DEPLOYMENT_TARGET=$(target_platform) \
+      -DCMAKE_INCLUDE_PATH="${CONDA_PREFIX}/include" \
+      -DCMAKE_LIBRARY_PATH="${CONDA_PREFIX}/lib" \
+      -DMAEPARSER_BUILD_SHARED_LIBS=$(shared_lib)
+    displayName: Configure build (Run CMake)
+  - bash: |
+      source ${CONDA}/etc/profile.d/conda.sh
+      conda activate maeparser_build
+      export SDKROOT="$(pwd)/MacOSX$(target_platform).sdk/"
+      export CONDA_BUILD_SYSROOT=${SDKROOT}
+      cd build
+      make -j $( $(number_of_cores) )
+    displayName: Build
+  - bash: |
+      source ${CONDA}/etc/profile.d/conda.sh
+      conda activate maeparser_build
+      export DYLD_FALLBACK_LIBRARY_PATH=${CONDA_PREFIX}/lib:${DYLD_FALLBACK_LIBRARY_PATH}
+      export SDKROOT="$(pwd)/MacOSX$(target_platform).sdk/"
+      export CONDA_BUILD_SYSROOT=${SDKROOT}
+      cd build
+      ctest -j $( $(number_of_cores) ) --output-on-failure -T Test
+    displayName: Run tests
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: "CTest"
+      testResultsFiles: "build/Testing/*/Test.xml"
+      testRunTitle: $(system.phasedisplayname) CTest Test Run

--- a/.azure-pipelines/vs_build.yml
+++ b/.azure-pipelines/vs_build.yml
@@ -1,37 +1,38 @@
 steps:
-- powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
-  displayName: Setup build environment
-- script: |
-    conda config --set always_yes yes --set changeps1 no
-    conda info -a
-    conda create --name maeparser_build $(compiler) cmake ^
-        boost-cpp=$(boost_version) boost=$(boost_version) ^
-        py-boost=$(boost_version) libboost=$(boost_version)
-  displayName: Install dependencies
-- script: |
-    set Boost_ROOT=
-    mkdir build && cd build
-    call activate maeparser_build
-    cmake .. ^
-    -G "Visual Studio 15 2017 Win64" ^
-    -DCMAKE_BUILD_TYPE=Release ^
-    -DMAEPARSER_RIGOROUS_BUILD=ON ^
-    -DBoost_NO_SYSTEM_PATHS=ON ^
-    -DCMAKE_INCLUDE_PATH=%CONDA_PREFIX%/Library/include ^
-    -DCMAKE_LIBRARY_PATH="%CONDA_PREFIX%/Library/lib
-  displayName: Configure build (Run CMake)
-- script: |
-    call activate maeparser_build
-    cd build
-    cmake --build . --config Release -j $(number_of_cores)
-  displayName: Build
-- script: |
-    call activate maeparser_build
-    cd build
-    ctest -j $(number_of_cores) --output-on-failure -T Test -C Release
-  displayName: Run tests
-- task: PublishTestResults@2
-  inputs:
-    testResultsFormat: 'CTest'
-    testResultsFiles: 'build/Testing/*/Test.xml'
-    testRunTitle: $(system.phasedisplayname)  CTest Test Run
+  - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+    displayName: Setup build environment
+  - script: |
+      conda config --set always_yes yes --set changeps1 no
+      conda info -a
+      conda create --name maeparser_build $(compiler) cmake ^
+          boost-cpp=$(boost_version) boost=$(boost_version) ^
+          py-boost=$(boost_version) libboost=$(boost_version)
+    displayName: Install dependencies
+  - script: |
+      set Boost_ROOT=
+      mkdir build && cd build
+      call activate maeparser_build
+      cmake .. ^
+      -G "Visual Studio 15 2017 Win64" ^
+      -DCMAKE_BUILD_TYPE=Release ^
+      -DMAEPARSER_RIGOROUS_BUILD=ON ^
+      -DBoost_NO_SYSTEM_PATHS=ON ^
+      -DCMAKE_INCLUDE_PATH=%CONDA_PREFIX%/Library/include ^
+      -DCMAKE_LIBRARY_PATH=%CONDA_PREFIX%/Library/lib ^
+      -DMAEPARSER_BUILD_SHARED_LIBS=$(shared_lib)
+    displayName: Configure build (Run CMake)
+  - script: |
+      call activate maeparser_build
+      cd build
+      cmake --build . --config Release -j $(number_of_cores)
+    displayName: Build
+  - script: |
+      call activate maeparser_build
+      cd build
+      ctest -j $(number_of_cores) --output-on-failure -T Test -C Release
+    displayName: Run tests
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: "CTest"
+      testResultsFiles: "build/Testing/*/Test.xml"
+      testRunTitle: $(system.phasedisplayname)  CTest Test Run

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,10 +39,19 @@ endif(MAEPARSER_BUILD_SHARED_LIBS)
 
 find_package(Boost COMPONENTS iostreams REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
+set(boost_libs ${Boost_LIBRARIES})
 
-find_package(ZLIB REQUIRED)
+find_package(Boost COMPONENTS zlib QUIET)
+if(Boost_ZLIB_FOUND)
+    set(boost_libs ${boost_libs} ${Boost_LIBRARIES})
+    message(STATUS "Using Boost zlib module for iostreams dependency.")
+else(Boost_ZLIB_FOUND)
+    find_package(ZLIB REQUIRED)
+    set(boost_libs ${boost_libs} ${ZLIB_LIBRARIES})
+    message(STATUS "Using zlib library for iostreams dependency.")
+endif(Boost_ZLIB_FOUND)
 
-target_link_libraries(maeparser Boost::iostreams ZLIB::ZLIB)
+target_link_libraries(maeparser ${boost_libs})
 
 SET_TARGET_PROPERTIES (maeparser
     PROPERTIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,10 +5,12 @@ project(maeparser)
 
 option(MAEPARSER_RIGOROUS_BUILD "Abort the build if the compiler issues any warnings" OFF )
 option(MAEPARSER_BUILD_TESTS "Whether test executables should be built" ON)
+option(MAEPARSER_BUILD_SHARED_LIBS "Build maeparser as a shared library (turn off for a static one)" ON)
 
 if(MSVC)
     # C4251 disables warnings for export STL containers as arguments (returning a vector of things)
     add_definitions(/wd4251 /wd4275 /wd4996 /D_SCL_SECURE_NO_WARNINGS /D_CRT_SECURE_NO_WARNINGS)
+    add_definitions(-DBOOST_ALL_NO_LIB)
 endif(MSVC)
 
 if(MAEPARSER_RIGOROUS_BUILD)
@@ -19,17 +21,34 @@ else(MSVC)
 endif(MSVC)
 endif(MAEPARSER_RIGOROUS_BUILD)
 
-find_package(Boost COMPONENTS filesystem iostreams unit_test_framework REQUIRED)
+file(GLOB mae_sources "*.cpp")
 
+if(MAEPARSER_BUILD_SHARED_LIBS)
+    add_library(maeparser SHARED ${mae_sources})
+    target_compile_definitions(maeparser PRIVATE "IN_MAEPARSER")
+    target_compile_definitions(maeparser PRIVATE "BOOST_ALL_DYN_LINK")
+    set_property(TARGET maeparser PROPERTY CXX_VISIBILITY_PRESET "hidden")
+else(MAEPARSER_BUILD_SHARED_LIBS)
+    set(Boost_USE_STATIC_LIBS ON)
+    if(NOT MSVC)
+        set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+    endif()
+    add_library(maeparser STATIC ${mae_sources})
+    target_compile_definitions(maeparser PRIVATE "STATIC_MAEPARSER")
+endif(MAEPARSER_BUILD_SHARED_LIBS)
+
+find_package(Boost COMPONENTS iostreams REQUIRED)
 include_directories(${Boost_INCLUDE_DIRS})
 
-add_library(maeparser SHARED Buffer.cpp MaeBlock.cpp MaeParser.cpp Reader.cpp Writer.cpp)
+find_package(ZLIB REQUIRED)
+
+target_link_libraries(maeparser Boost::iostreams ZLIB::ZLIB)
+
 SET_TARGET_PROPERTIES (maeparser
     PROPERTIES
        VERSION 1.2.2
        SOVERSION 1
 )
-target_link_libraries(maeparser Boost::disable_autolinking Boost::dynamic_linking Boost::iostreams)
 
 target_include_directories(maeparser PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
@@ -47,10 +66,6 @@ INSTALL(EXPORT maeparser-targets
 
 file(GLOB mae_headers "*.hpp")
 install(FILES ${mae_headers} DESTINATION include/maeparser)
-
-target_compile_definitions(maeparser PRIVATE IN_MAEPARSER)
-
-set_property(TARGET maeparser PROPERTY CXX_VISIBILITY_PRESET "hidden")
 
 # Tests
 if (MAEPARSER_BUILD_TESTS)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,39 +1,79 @@
 trigger:
-- master
-- dev/*
+  - master
+  - dev/*
 
 jobs:
-- job: Ubuntu_16_04_x64
-  timeoutInMinutes: 90
-  pool:
-    vmImage: ubuntu-16.04
-  variables:
-    compiler: gxx_linux-64=7.2.0
-    boost_version: 1.67.0
-    number_of_cores: nproc
-    python_name: python37
-  steps:
-  - template: .azure-pipelines/linux_build.yml
-- job: macOS_10_13_x64
-  timeoutInMinutes: 90
-  pool:
-    vmImage: macos-10.13
-  variables:
-    compiler: clangxx_osx-64
-    boost_version: 1.67.0
-    number_of_cores: sysctl -n hw.ncpu
-    python_name: python37
-    target_platform: 10.9
-  steps:
-  - template: .azure-pipelines/mac_build.yml
-- job: Windows_VS2017_x64
-  timeoutInMinutes: 90
-  pool:
-    vmImage: vs2017-win2016
-  variables:
-    compiler: vs2017_win-64
-    boost_version: 1.67.0
-    number_of_cores: '%NUMBER_OF_PROCESSORS%'
-    python_name: python37
-  steps:
-  - template: .azure-pipelines/vs_build.yml
+  - job: Ubuntu_16_04_x64
+    timeoutInMinutes: 90
+    pool:
+      vmImage: ubuntu-16.04
+    variables:
+      compiler: gxx_linux-64=7.2.0
+      boost_version: 1.67.0
+      number_of_cores: nproc
+      python_name: python37
+      shared_lib: ON
+    steps:
+      - template: .azure-pipelines/linux_build.yml
+  - job: Ubuntu_16_04_x64_static
+    timeoutInMinutes: 90
+    pool:
+      vmImage: ubuntu-16.04
+    variables:
+      compiler: gxx_linux-64=7.2.0
+      boost_version: 1.67.0
+      number_of_cores: nproc
+      python_name: python37
+      shared_lib: OFF
+    steps:
+      - template: .azure-pipelines/linux_build.yml
+  - job: macOS_10_13_x64
+    timeoutInMinutes: 90
+    pool:
+      vmImage: macos-10.13
+    variables:
+      compiler: clangxx_osx-64
+      boost_version: 1.67.0
+      number_of_cores: sysctl -n hw.ncpu
+      python_name: python37
+      target_platform: 10.9
+      shared_lib: ON
+    steps:
+      - template: .azure-pipelines/mac_build.yml
+  - job: macOS_10_13_x64_static
+    timeoutInMinutes: 90
+    pool:
+      vmImage: macos-10.13
+    variables:
+      compiler: clangxx_osx-64
+      boost_version: 1.67.0
+      number_of_cores: sysctl -n hw.ncpu
+      python_name: python37
+      target_platform: 10.9
+      shared_lib: OFF
+    steps:
+      - template: .azure-pipelines/mac_build.yml
+  - job: Windows_VS2017_x64
+    timeoutInMinutes: 90
+    pool:
+      vmImage: vs2017-win2016
+    variables:
+      compiler: vs2017_win-64
+      boost_version: 1.67.0
+      number_of_cores: "%NUMBER_OF_PROCESSORS%"
+      python_name: python37
+      shared_lib: ON
+    steps:
+      - template: .azure-pipelines/vs_build.yml
+  - job: Windows_VS2017_x64_static
+    timeoutInMinutes: 90
+    pool:
+      vmImage: vs2017-win2016
+    variables:
+      compiler: vs2017_win-64
+      boost_version: 1.67.0
+      number_of_cores: "%NUMBER_OF_PROCESSORS%"
+      python_name: python37
+      shared_lib: OFF
+    steps:
+      - template: .azure-pipelines/vs_build.yml

--- a/test/BufferTest.cpp
+++ b/test/BufferTest.cpp
@@ -5,8 +5,6 @@
 #include <sstream>
 #include <stdexcept>
 
-#define BOOST_TEST_DYN_LINK
-
 #include <boost/test/unit_test.hpp>
 
 #include "Buffer.hpp"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,18 +1,27 @@
 include_directories(..)
 
-add_executable(unittest
-    MainTestSuite.cpp BufferTest.cpp MaeBlockTest.cpp MaeParserTest.cpp ReaderTest.cpp WriterTest.cpp UsageDemo.cpp)
+find_package(Boost COMPONENTS filesystem iostreams unit_test_framework REQUIRED)
 
-target_link_libraries(unittest maeparser Boost::unit_test_framework Boost::filesystem)
+add_executable(unittest MainTestSuite.cpp BufferTest.cpp MaeBlockTest.cpp MaeParserTest.cpp
+               ReaderTest.cpp WriterTest.cpp UsageDemo.cpp)
+
+if(MAEPARSER_BUILD_SHARED_LIBS)
+    target_compile_definitions(unittest PRIVATE "BOOST_ALL_DYN_LINK")
+else(MAEPARSER_BUILD_SHARED_LIBS)
+    target_compile_definitions(unittest PRIVATE "STATIC_MAEPARSER")
+endif(MAEPARSER_BUILD_SHARED_LIBS)
 
 get_filename_component(TEST_SAMPLES_PATH ${CMAKE_CURRENT_SOURCE_DIR} ABSOLUTE)
 target_compile_definitions(unittest PRIVATE "TEST_SAMPLES_PATH=\"${TEST_SAMPLES_PATH}\"")
 
+target_link_libraries(unittest maeparser ${Boost_LIBRARIES})
+
 add_test(NAME unittest COMMAND ${CMAKE_CURRENT_BINARY_DIR}/unittest
          WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
-if(MSVC)
-    add_custom_command(TARGET unittest POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different
-    "${PROJECT_BINARY_DIR}/\$\(Configuration\)/maeparser.dll" "${CMAKE_CURRENT_BINARY_DIR}/\$\(Configuration\)/maeparser.dll")
-endif(MSVC)
+if(MSVC AND MAEPARSER_BUILD_SHARED_LIBS)
+    add_custom_command(TARGET unittest POST_BUILD COMMAND ${CMAKE_COMMAND}
+    -E copy_if_different "${PROJECT_BINARY_DIR}/\$\(Configuration\)/maeparser.dll"
+    "${CMAKE_CURRENT_BINARY_DIR}/\$\(Configuration\)/maeparser.dll")
+endif(MSVC AND MAEPARSER_BUILD_SHARED_LIBS)
 

--- a/test/MaeBlockTest.cpp
+++ b/test/MaeBlockTest.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 #include <stdexcept>
 
-#define BOOST_TEST_DYN_LINK
 #include <boost/test/unit_test.hpp>
 
 #include "MaeBlock.hpp"

--- a/test/MaeParserTest.cpp
+++ b/test/MaeParserTest.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 
-#define BOOST_TEST_DYN_LINK
 #include <boost/algorithm/string.hpp>
 #include <boost/test/unit_test.hpp>
 

--- a/test/MainTestSuite.cpp
+++ b/test/MainTestSuite.cpp
@@ -1,4 +1,3 @@
 #define BOOST_TEST_MODULE mae_reader_test
-#define BOOST_TEST_DYN_LINK
 
 #include <boost/test/unit_test.hpp>

--- a/test/ReaderTest.cpp
+++ b/test/ReaderTest.cpp
@@ -2,9 +2,8 @@
 #include <fstream>
 #include <iostream>
 
-#define BOOST_TEST_DYN_LINK
-#include <boost/test/unit_test.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include "MaeBlock.hpp"
 #include "MaeConstants.hpp"
@@ -320,7 +319,8 @@ BOOST_AUTO_TEST_CASE(QuotedStringTest)
 BOOST_AUTO_TEST_CASE(TestReadNonExistingFile)
 {
     // This file should not exist!
-    CheckExceptionMsg<std::runtime_error> check_msg("Failed to open file \"non_existing_file.mae\" for reading operation");
+    CheckExceptionMsg<std::runtime_error> check_msg(
+        "Failed to open file \"non_existing_file.mae\" for reading operation");
 
     BOOST_CHECK_EXCEPTION(Reader r("non_existing_file.mae"), std::runtime_error,
                           check_msg);

--- a/test/UsageDemo.cpp
+++ b/test/UsageDemo.cpp
@@ -20,10 +20,8 @@
 #include "MaeConstants.hpp"
 #include "Reader.hpp"
 
-#define BOOST_TEST_DYN_LINK
-
-#include <boost/test/unit_test.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
 
 using namespace schrodinger::mae;
 

--- a/test/WriterTest.cpp
+++ b/test/WriterTest.cpp
@@ -6,12 +6,11 @@
 #include "MaeBlock.hpp"
 #include "MaeConstants.hpp"
 #include "Reader.hpp"
-#include "Writer.hpp"
 #include "TestCommon.hpp"
+#include "Writer.hpp"
 
-#define BOOST_TEST_DYN_LINK
-#include <boost/test/unit_test.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
 
 using namespace schrodinger::mae;
 using std::shared_ptr;
@@ -86,9 +85,12 @@ BOOST_AUTO_TEST_CASE(Writer1)
 BOOST_AUTO_TEST_CASE(TestWriteNonAccessiblePath)
 {
     // This path should not exist/be accesible!
-    CheckExceptionMsg<std::runtime_error> check_msg("Failed to open file \"/non/accessible/path/file.mae\" for writing operation");
+    CheckExceptionMsg<std::runtime_error> check_msg(
+        "Failed to open file \"/non/accessible/path/file.mae\" for writing "
+        "operation");
 
-    BOOST_CHECK_EXCEPTION(Writer w("/non/accessible/path/file.mae")    , std::runtime_error, check_msg);
+    BOOST_CHECK_EXCEPTION(Writer w("/non/accessible/path/file.mae"),
+                          std::runtime_error, check_msg);
 }
 
 /*


### PR DESCRIPTION
This PR implements an option to switch between building shared and static libraries (it addresses #56).

The relevant changes are in the CMake files, where I added the `MAEPARSER_BUILD_SHARED_LIBS` flag to select what kind of library will be built: `ON` will build a shared library, while `OFF` will build a static one. The required dependencies (boost, zlib), as well as the unit tests, will use the same linking type as specified by the flag. For the tests, this meant removing the `BOOST_TEST_DYN_LINK` macro from the source files to allow switching between shared/static linking.

I also added some new Azure pipelines to check the building of static libraries. Changes in the azure files look bigger than they really are due to whitespace adjustments. In fact, I just duplicated the "jobs" in the main azure-pipelines file, and added the `shared_lib` flag. In the per platform templates, I just added the link type flag. These builds have already been checked out in my repo's CI builds: https://dev.azure.com/ricrogz/mymaeparser/_build/results?buildId=392.

Please note that the Travis and appveyor builds do not exercise the static builds.

There's a matching PR for coordgen which depends on this one: https://github.com/schrodinger/coordgenlibs/pull/43

As an additional check, I made sure that using this and the coordgen path, both RDKit and OpenBabel can be built without any updates.



