### PR TITLE
Bump azure MacOS versions

### DIFF
--- a/.azure-pipelines/mac_build.yml
+++ b/.azure-pipelines/mac_build.yml
@@ -1,6 +1,6 @@
 steps:
   - bash: |
-      wget https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX$(target_platform).sdk.tar.xz
+      wget https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX$(target_platform).sdk.tar.xz
       tar Jxvf MacOSX$(target_platform).sdk.tar.xz
     displayName: Install MacOSX $(target_platform) SDK
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,10 +27,10 @@ jobs:
       shared_lib: OFF
     steps:
       - template: .azure-pipelines/linux_build.yml
-  - job: macOS_10_13_x64
+  - job: macOS_10_14_x64
     timeoutInMinutes: 90
     pool:
-      vmImage: macos-10.13
+      vmImage: macos-10.14
     variables:
       compiler: clangxx_osx-64
       boost_version: 1.67.0
@@ -40,10 +40,10 @@ jobs:
       shared_lib: ON
     steps:
       - template: .azure-pipelines/mac_build.yml
-  - job: macOS_10_13_x64_static
+  - job: macOS_10_14_x64_static
     timeoutInMinutes: 90
     pool:
-      vmImage: macos-10.13
+      vmImage: macos-10.14
     variables:
       compiler: clangxx_osx-64
       boost_version: 1.67.0


### PR DESCRIPTION
Azure Pipelines dumped MacOS 10.13 machines. This updates the pipelines to use 10.14 machines.

We don't use Pipelines here yet, but we should keep the versions up to date for when we do. Also, this allows me to use pipelines on my private repo without having to rebase back and forth to open PRs here.