### PR TITLE
Block::getIndexedBlock() should be const

### DIFF
--- a/MaeBlock.cpp
+++ b/MaeBlock.cpp
@@ -160,7 +160,7 @@ string Block::toString() const
     return stream.str();
 }
 
-shared_ptr<const IndexedBlock> Block::getIndexedBlock(const string& name)
+shared_ptr<const IndexedBlock> Block::getIndexedBlock(const string& name) const
 {
     if (!hasIndexedBlockData()) {
         throw out_of_range("Indexed block not found: " + name);
@@ -373,8 +373,8 @@ bool IndexedProperty<T>::operator==(const IndexedProperty<T>& rhs) const
 // For doubles we need to implement our own comparator for the vectors to
 // take precision into account
 template <>
-bool IndexedProperty<double>::
-operator==(const IndexedProperty<double>& rhs) const
+bool IndexedProperty<double>::operator==(
+    const IndexedProperty<double>& rhs) const
 {
     if (m_is_null == nullptr || rhs.m_is_null == nullptr) {
         if ((m_is_null == nullptr) != (rhs.m_is_null == nullptr))

--- a/MaeBlock.hpp
+++ b/MaeBlock.hpp
@@ -150,7 +150,7 @@ class EXPORT_MAEPARSER Block
     }
 
     std::shared_ptr<const IndexedBlock>
-    getIndexedBlock(const std::string& name);
+    getIndexedBlock(const std::string& name) const;
 
     void addBlock(std::shared_ptr<Block> b) { m_sub_block[b->getName()] = b; }
 


### PR DESCRIPTION
While working on RDKit I noticed this method is not const, while it should be.

Checks passed on all three platforms (after bumping MacOS version): https://dev.azure.com/ricrogz/mymaeparser/_build/results?buildId=470