### PR TITLE
Apply Clang tidy modernize & performance

### DIFF
--- a/Buffer.hpp
+++ b/Buffer.hpp
@@ -305,21 +305,6 @@ class EXPORT_MAEPARSER TokenBufferList
   public:
     TokenBufferList() : m_token_buffer_list(), m_begin(), m_end() {}
 
-    ///
-    //  Create a TokenBufferList from an initial Buffer and the number of
-    //  values you expect to be collected. The number of collected tokens
-    //  isn't limited to this value, it's just used to reserve space for
-    //  storage.
-    //
-    explicit TokenBufferList(const BufferData& buffer_data, size_t values = 0)
-        : TokenBufferList()
-    {
-        reserve(values);
-        if (buffer_data.size() != 0) {
-            m_token_buffer_list.emplace_back(buffer_data, 0);
-        }
-    }
-
     void reserve(size_t size)
     {
         m_begin.reserve(size);

--- a/Buffer.hpp
+++ b/Buffer.hpp
@@ -11,6 +11,7 @@
 #include <memory>
 #include <sstream>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 #include "MaeParserConfig.hpp"
@@ -74,7 +75,7 @@ class BufferLoader
     {
     }
 
-    virtual ~BufferLoader() {}
+    virtual ~BufferLoader() = default;
 
     /**
      * Return the default buffer size for this BufferLoader. This should be
@@ -133,7 +134,7 @@ class StreamLoader : public BufferLoader
     StreamLoader(const StreamLoader&) = delete;
     StreamLoader& operator=(const StreamLoader&) = delete;
 
-    virtual size_t readData(char* ptr, size_t size) const override;
+    size_t readData(char* ptr, size_t size) const override;
 };
 
 /**
@@ -154,7 +155,7 @@ class FileLoader : public BufferLoader
   public:
     FileLoader(FILE* file) : m_file(file) {}
 
-    virtual size_t readData(char* ptr, size_t size) const override;
+    size_t readData(char* ptr, size_t size) const override;
 };
 
 /**
@@ -285,7 +286,8 @@ class EXPORT_MAEPARSER TokenBufferList
         size_t last_value;
 
         TokenBuffer(BufferData data, size_t next_index)
-            : buffer_data(data), first_value(next_index), last_value(next_index)
+            : buffer_data(std::move(data)), first_value(next_index),
+              last_value(next_index)
         {
         }
     };
@@ -366,12 +368,12 @@ class BufferDataCollector : public BufferLoader
         m_buffer->setBufferLoader(this);
     }
 
-    ~BufferDataCollector() { m_buffer->setBufferLoader(m_loader); }
+    ~BufferDataCollector() override { m_buffer->setBufferLoader(m_loader); }
 
-    virtual bool load(BufferData& data, const char* begin,
-                      const char* end) const override;
+    bool load(BufferData& data, const char* begin,
+              const char* end) const override;
 
-    virtual size_t readData(char* ptr, size_t size) const override;
+    size_t readData(char* ptr, size_t size) const override;
 };
 
 } // end namespace schrodinger

--- a/Buffer.hpp
+++ b/Buffer.hpp
@@ -311,7 +311,7 @@ class EXPORT_MAEPARSER TokenBufferList
     //  isn't limited to this value, it's just used to reserve space for
     //  storage.
     //
-    explicit TokenBufferList(BufferData buffer_data, size_t values = 0)
+    explicit TokenBufferList(const BufferData& buffer_data, size_t values = 0)
         : TokenBufferList()
     {
         reserve(values);

--- a/MaeBlock.cpp
+++ b/MaeBlock.cpp
@@ -1,5 +1,6 @@
 #include "MaeBlock.hpp"
 #include <cmath>
+#include <utility>
 
 #include "MaeParser.hpp"
 
@@ -264,7 +265,7 @@ EXPORT_MAEPARSER void
 IndexedBlock::setProperty<BoolProperty>(const string& name,
                                         shared_ptr<IndexedBoolProperty> value)
 {
-    set_indexed_property<IndexedBoolProperty>(m_bmap, name, value);
+    set_indexed_property<IndexedBoolProperty>(m_bmap, name, std::move(value));
 }
 
 template <>
@@ -272,7 +273,8 @@ EXPORT_MAEPARSER void
 IndexedBlock::setProperty<double>(const string& name,
                                   shared_ptr<IndexedProperty<double>> value)
 {
-    set_indexed_property<IndexedProperty<double>>(m_rmap, name, value);
+    set_indexed_property<IndexedProperty<double>>(m_rmap, name,
+                                                  std::move(value));
 }
 
 template <>
@@ -280,7 +282,7 @@ EXPORT_MAEPARSER void
 IndexedBlock::setProperty<int>(const string& name,
                                shared_ptr<IndexedProperty<int>> value)
 {
-    set_indexed_property<IndexedProperty<int>>(m_imap, name, value);
+    set_indexed_property<IndexedProperty<int>>(m_imap, name, std::move(value));
 }
 
 template <>
@@ -288,7 +290,8 @@ EXPORT_MAEPARSER void
 IndexedBlock::setProperty<string>(const string& name,
                                   shared_ptr<IndexedProperty<string>> value)
 {
-    set_indexed_property<IndexedProperty<string>>(m_smap, name, value);
+    set_indexed_property<IndexedProperty<string>>(m_smap, name,
+                                                  std::move(value));
 }
 
 size_t IndexedBlock::size() const

--- a/MaeBlock.cpp
+++ b/MaeBlock.cpp
@@ -223,8 +223,7 @@ bool IndexedBlockMap::hasIndexedBlock(const string& name) const
 shared_ptr<const IndexedBlock>
 IndexedBlockMap::getIndexedBlock(const string& name) const
 {
-    map<string, shared_ptr<IndexedBlock>>::const_iterator block_iter =
-        m_indexed_block.find(name);
+    auto block_iter = m_indexed_block.find(name);
     if (block_iter != m_indexed_block.end()) {
         return const_pointer_cast<const IndexedBlock>(block_iter->second);
     } else {
@@ -246,8 +245,7 @@ bool BufferedIndexedBlockMap::hasIndexedBlock(const string& name) const
 shared_ptr<const IndexedBlock>
 BufferedIndexedBlockMap::getIndexedBlock(const string& name) const
 {
-    map<string, shared_ptr<IndexedBlock>>::const_iterator itb =
-        m_indexed_block.find(name);
+    auto itb = m_indexed_block.find(name);
     if (itb != m_indexed_block.end()) {
         return itb->second;
     }

--- a/MaeBlock.hpp
+++ b/MaeBlock.hpp
@@ -13,7 +13,7 @@ namespace schrodinger
 {
 namespace mae
 {
-typedef uint8_t BoolProperty;
+using BoolProperty = uint8_t;
 
 template <typename T>
 inline const T& get_property(const std::map<std::string, T>& map,
@@ -50,12 +50,12 @@ class EXPORT_MAEPARSER IndexedBlockMap : public IndexedBlockMapI
     std::map<std::string, std::shared_ptr<IndexedBlock>> m_indexed_block;
 
   public:
-    virtual bool hasIndexedBlock(const std::string& name) const;
+    bool hasIndexedBlock(const std::string& name) const override;
 
-    virtual std::shared_ptr<const IndexedBlock>
-    getIndexedBlock(const std::string& name) const;
+    std::shared_ptr<const IndexedBlock>
+    getIndexedBlock(const std::string& name) const override;
 
-    virtual std::vector<std::string> getBlockNames() const
+    std::vector<std::string> getBlockNames() const override
     {
         std::vector<std::string> rval;
         for (const auto& p : m_indexed_block) {
@@ -82,12 +82,12 @@ class EXPORT_MAEPARSER BufferedIndexedBlockMap : public IndexedBlockMapI
     std::map<std::string, std::shared_ptr<IndexedBlockBuffer>> m_indexed_buffer;
 
   public:
-    virtual bool hasIndexedBlock(const std::string& name) const;
+    bool hasIndexedBlock(const std::string& name) const override;
 
-    virtual std::shared_ptr<const IndexedBlock>
-    getIndexedBlock(const std::string& name) const;
+    std::shared_ptr<const IndexedBlock>
+    getIndexedBlock(const std::string& name) const override;
 
-    virtual std::vector<std::string> getBlockNames() const
+    std::vector<std::string> getBlockNames() const override
     {
         std::vector<std::string> rval;
         for (const auto& p : m_indexed_buffer) {
@@ -254,7 +254,7 @@ template <typename T> class IndexedProperty
     IndexedProperty<T>& operator=(const IndexedProperty<T>&) = delete;
 
   public:
-    typedef typename std::vector<T>::size_type size_type;
+    using size_type = typename std::vector<T>::size_type;
 
     /**
      * Construct an IndexedProperty from a reference to a vector of data.
@@ -344,10 +344,10 @@ template <typename T> class IndexedProperty
     const boost::dynamic_bitset<>* nullIndices() const { return m_is_null; }
 };
 
-typedef IndexedProperty<double> IndexedRealProperty;
-typedef IndexedProperty<int> IndexedIntProperty;
-typedef IndexedProperty<BoolProperty> IndexedBoolProperty;
-typedef IndexedProperty<std::string> IndexedStringProperty;
+using IndexedRealProperty = IndexedProperty<double>;
+using IndexedIntProperty = IndexedProperty<int>;
+using IndexedBoolProperty = IndexedProperty<BoolProperty>;
+using IndexedStringProperty = IndexedProperty<std::string>;
 
 template <typename T>
 inline std::shared_ptr<T>

--- a/MaeBlock.hpp
+++ b/MaeBlock.hpp
@@ -6,6 +6,7 @@
 #include <map>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 #include "MaeParserConfig.hpp"
 
@@ -71,7 +72,7 @@ class EXPORT_MAEPARSER IndexedBlockMap : public IndexedBlockMapI
     void addIndexedBlock(const std::string& name,
                          std::shared_ptr<IndexedBlock> indexed_block)
     {
-        m_indexed_block[name] = indexed_block;
+        m_indexed_block[name] = std::move(indexed_block);
     }
 };
 
@@ -104,7 +105,7 @@ class EXPORT_MAEPARSER BufferedIndexedBlockMap : public IndexedBlockMapI
     void addIndexedBlockBuffer(const std::string& name,
                                std::shared_ptr<IndexedBlockBuffer> block_buffer)
     {
-        m_indexed_buffer[name] = block_buffer;
+        m_indexed_buffer[name] = std::move(block_buffer);
     }
 };
 
@@ -139,7 +140,7 @@ class EXPORT_MAEPARSER Block
 
     void setIndexedBlockMap(std::shared_ptr<IndexedBlockMapI> indexed_block_map)
     {
-        m_indexed_block_map = indexed_block_map;
+        m_indexed_block_map = std::move(indexed_block_map);
     }
 
     bool hasIndexedBlockData() const { return m_indexed_block_map != nullptr; }
@@ -152,7 +153,10 @@ class EXPORT_MAEPARSER Block
     std::shared_ptr<const IndexedBlock>
     getIndexedBlock(const std::string& name) const;
 
-    void addBlock(std::shared_ptr<Block> b) { m_sub_block[b->getName()] = b; }
+    void addBlock(const std::shared_ptr<Block>& b)
+    {
+        m_sub_block[b->getName()] = b;
+    }
 
     /**
      * Check whether this block has a sub-block of the provided name.
@@ -427,7 +431,8 @@ class EXPORT_MAEPARSER IndexedBlock
     void setBoolProperty(const std::string& name,
                          std::shared_ptr<IndexedBoolProperty> value)
     {
-        set_indexed_property<IndexedBoolProperty>(m_bmap, name, value);
+        set_indexed_property<IndexedBoolProperty>(m_bmap, name,
+                                                  std::move(value));
     }
 
     bool hasIntProperty(const std::string& name) const
@@ -444,7 +449,8 @@ class EXPORT_MAEPARSER IndexedBlock
     void setIntProperty(const std::string& name,
                         std::shared_ptr<IndexedIntProperty> value)
     {
-        set_indexed_property<IndexedIntProperty>(m_imap, name, value);
+        set_indexed_property<IndexedIntProperty>(m_imap, name,
+                                                 std::move(value));
     }
 
     bool hasRealProperty(const std::string& name) const
@@ -461,7 +467,8 @@ class EXPORT_MAEPARSER IndexedBlock
     void setRealProperty(const std::string& name,
                          std::shared_ptr<IndexedRealProperty> value)
     {
-        set_indexed_property<IndexedRealProperty>(m_rmap, name, value);
+        set_indexed_property<IndexedRealProperty>(m_rmap, name,
+                                                  std::move(value));
     }
 
     bool hasStringProperty(const std::string& name) const
@@ -478,7 +485,8 @@ class EXPORT_MAEPARSER IndexedBlock
     void setStringProperty(const std::string& name,
                            std::shared_ptr<IndexedStringProperty> value)
     {
-        set_indexed_property<IndexedStringProperty>(m_smap, name, value);
+        set_indexed_property<IndexedStringProperty>(m_smap, name,
+                                                    std::move(value));
     }
 
     template <typename T>

--- a/MaeBlock.hpp
+++ b/MaeBlock.hpp
@@ -120,11 +120,11 @@ class EXPORT_MAEPARSER Block
     std::map<std::string, std::shared_ptr<Block>> m_sub_block;
     std::shared_ptr<IndexedBlockMapI> m_indexed_block_map;
 
+  public:
     // Prevent copying.
     Block(const Block&) = delete;
     Block& operator=(const Block&) = delete;
 
-  public:
     Block(std::string name)
         : m_name(std::move(name)), m_bmap(), m_rmap(), m_imap(), m_smap(),
           m_indexed_block_map(nullptr)
@@ -249,11 +249,11 @@ template <typename T> class IndexedProperty
     std::vector<T> m_data;
     boost::dynamic_bitset<>* m_is_null;
 
+  public:
     // Prevent copying.
     IndexedProperty<T>(const IndexedProperty<T>&) = delete;
     IndexedProperty<T>& operator=(const IndexedProperty<T>&) = delete;
 
-  public:
     using size_type = typename std::vector<T>::size_type;
 
     /**
@@ -381,11 +381,11 @@ class EXPORT_MAEPARSER IndexedBlock
     std::map<std::string, std::shared_ptr<IndexedRealProperty>> m_rmap;
     std::map<std::string, std::shared_ptr<IndexedStringProperty>> m_smap;
 
+  public:
     // Prevent copying.
     IndexedBlock(const IndexedBlock&) = delete;
     IndexedBlock& operator=(const IndexedBlock&) = delete;
 
-  public:
     /**
      * Create an indexed block.
      */

--- a/MaeBlock.hpp
+++ b/MaeBlock.hpp
@@ -70,7 +70,7 @@ class EXPORT_MAEPARSER IndexedBlockMap : public IndexedBlockMapI
      * Add an IndexedBlock to the map.
      */
     void addIndexedBlock(const std::string& name,
-                         std::shared_ptr<IndexedBlock> indexed_block)
+                         std::shared_ptr<IndexedBlock>&& indexed_block)
     {
         m_indexed_block[name] = std::move(indexed_block);
     }
@@ -102,8 +102,9 @@ class EXPORT_MAEPARSER BufferedIndexedBlockMap : public IndexedBlockMapI
      * Add an IndexedBlockBuffer to the map, which can be used to retrieve an
      * IndexedBlock.
      */
-    void addIndexedBlockBuffer(const std::string& name,
-                               std::shared_ptr<IndexedBlockBuffer> block_buffer)
+    void
+    addIndexedBlockBuffer(const std::string& name,
+                          std::shared_ptr<IndexedBlockBuffer>&& block_buffer)
     {
         m_indexed_buffer[name] = std::move(block_buffer);
     }
@@ -153,10 +154,7 @@ class EXPORT_MAEPARSER Block
     std::shared_ptr<const IndexedBlock>
     getIndexedBlock(const std::string& name) const;
 
-    void addBlock(const std::shared_ptr<Block>& b)
-    {
-        m_sub_block[b->getName()] = b;
-    }
+    void addBlock(std::shared_ptr<Block>&& b) { m_sub_block[b->getName()] = b; }
 
     /**
      * Check whether this block has a sub-block of the provided name.

--- a/MaeConstants.hpp
+++ b/MaeConstants.hpp
@@ -62,6 +62,5 @@ const std::string CT_EZ_PROP_PREFIX = "s_st_EZ_";
  */
 const std::string CT_PSEUDOCHIRALITY_PROP_PREFIX = "s_st_AtomNumChirality_";
 
-
 } // End namespace mae
 } // End namespace schrodinger

--- a/MaeParser.cpp
+++ b/MaeParser.cpp
@@ -651,7 +651,7 @@ static long int simple_strtol(const char* ptr, const char* end)
 
 IndexedBlock* IndexedBlockBuffer::getIndexedBlock()
 {
-    IndexedBlock* iblock = new IndexedBlock(getName());
+    auto* iblock = new IndexedBlock(getName());
 
     std::vector<std::string>::const_iterator iter = m_property_names.begin();
 

--- a/MaeParser.cpp
+++ b/MaeParser.cpp
@@ -367,8 +367,8 @@ std::shared_ptr<Block> MaeParser::blockBody(const std::string& name)
         if (indexed) {
             indexed_block_parser->parse(name, indexed, m_buffer);
         } else {
-            std::shared_ptr<Block> sub_block = blockBody(name);
-            block->addBlock(sub_block);
+            auto sub_block = blockBody(name);
+            block->addBlock(std::move(sub_block));
         }
     }
 
@@ -573,7 +573,7 @@ void DirectIndexedBlockParser::parse(const std::string& name, size_t size,
         parser->addToIndexedBlock(indexed_block.get());
         delete parser;
     }
-    m_indexed_block_map->addIndexedBlock(name, indexed_block);
+    m_indexed_block_map->addIndexedBlock(name, std::move(indexed_block));
 }
 
 std::shared_ptr<IndexedBlockMapI> DirectIndexedBlockParser::getIndexedBlockMap()
@@ -789,7 +789,7 @@ void BufferedIndexedBlockParser::parse(const std::string& name, size_t size,
     whitespace(buffer);
     std::shared_ptr<std::string> property_name;
     while ((property_name = property_key(buffer)) != nullptr) {
-        ibb->addPropertyName(*property_name);
+        ibb->addPropertyName(std::move(*property_name));
         whitespace(buffer);
     }
     triple_colon(buffer);
@@ -801,7 +801,7 @@ void BufferedIndexedBlockParser::parse(const std::string& name, size_t size,
         throw read_exception(buffer, "Missing closing '}' for "
                                      "indexed block.");
     }
-    m_indexed_block_map->addIndexedBlockBuffer(name, ibb);
+    m_indexed_block_map->addIndexedBlockBuffer(name, std::move(ibb));
 }
 
 } // end of namespace mae

--- a/MaeParser.hpp
+++ b/MaeParser.hpp
@@ -134,7 +134,7 @@ class EXPORT_MAEPARSER IndexedBlockBuffer
 
     virtual ~IndexedBlockBuffer() = default;
 
-    void addPropertyName(const std::string& name)
+    void addPropertyName(std::string&& name)
     {
         m_property_names.push_back(name);
     }

--- a/MaeParser.hpp
+++ b/MaeParser.hpp
@@ -331,9 +331,9 @@ class EXPORT_MAEPARSER MaeParser
 class EXPORT_MAEPARSER DirectMaeParser : public MaeParser
 {
   public:
-    explicit DirectMaeParser(std::shared_ptr<std::istream> stream,
+    explicit DirectMaeParser(const std::shared_ptr<std::istream>& stream,
                              size_t buffer_size = BufferLoader::DEFAULT_SIZE)
-        : MaeParser(std::move(stream), buffer_size)
+        : MaeParser(stream, buffer_size)
     {
     }
 

--- a/MaeParser.hpp
+++ b/MaeParser.hpp
@@ -134,7 +134,7 @@ class EXPORT_MAEPARSER IndexedBlockBuffer
 
     virtual ~IndexedBlockBuffer() = default;
 
-    void addPropertyName(const std::string name)
+    void addPropertyName(const std::string& name)
     {
         m_property_names.push_back(name);
     }
@@ -268,7 +268,7 @@ class EXPORT_MAEPARSER MaeParser
     }
 
   public:
-    explicit MaeParser(std::shared_ptr<std::istream> stream,
+    explicit MaeParser(const std::shared_ptr<std::istream>& stream,
                        size_t buffer_size = BufferLoader::DEFAULT_SIZE)
         : m_buffer(*stream, buffer_size), m_stream(stream)
     {
@@ -333,7 +333,7 @@ class EXPORT_MAEPARSER DirectMaeParser : public MaeParser
   public:
     explicit DirectMaeParser(std::shared_ptr<std::istream> stream,
                              size_t buffer_size = BufferLoader::DEFAULT_SIZE)
-        : MaeParser(stream, buffer_size)
+        : MaeParser(std::move(stream), buffer_size)
     {
     }
 

--- a/MaeParser.hpp
+++ b/MaeParser.hpp
@@ -1,6 +1,13 @@
 #ifndef MAE_READER_HPP_
 #define MAE_READER_HPP_
 
+// Visual Studio versions prior to 2015 don't support noexcept
+#if defined(_MSC_FULL_VER) && _MSC_FULL_VER < 190023026
+#define NOEXCEPT
+#else
+#define NOEXCEPT noexcept
+#endif
+
 #include <cerrno>
 #include <cstdio>
 #include <map>
@@ -88,7 +95,7 @@ class EXPORT_MAEPARSER read_exception : public std::exception
         format(line_number, column, msg);
     }
 
-    const char* what() const noexcept override { return m_msg; }
+    const char* what() const NOEXCEPT override { return m_msg; }
 };
 
 /**
@@ -101,7 +108,6 @@ class EXPORT_MAEPARSER Parser
   public:
     virtual void parse(Buffer& buffer) = 0;
     virtual ~Parser() = default;
-    ;
 };
 
 class EXPORT_MAEPARSER IndexedBlockParser
@@ -110,7 +116,6 @@ class EXPORT_MAEPARSER IndexedBlockParser
 
   public:
     virtual ~IndexedBlockParser() = default;
-    ;
 
     virtual void parse(const std::string& name, size_t size,
                        Buffer& buffer) = 0;

--- a/Reader.cpp
+++ b/Reader.cpp
@@ -26,7 +26,7 @@ Reader::Reader(FILE* file, size_t buffer_size)
 
 Reader::Reader(std::shared_ptr<std::istream> stream, size_t buffer_size)
 {
-    m_mae_parser.reset(new MaeParser(stream, buffer_size));
+    m_mae_parser.reset(new MaeParser(std::move(stream), buffer_size));
 }
 
 Reader::Reader(const std::string& fname, size_t buffer_size)

--- a/Reader.cpp
+++ b/Reader.cpp
@@ -24,9 +24,9 @@ Reader::Reader(FILE* file, size_t buffer_size)
     m_mae_parser.reset(new MaeParser(file, buffer_size));
 }
 
-Reader::Reader(std::shared_ptr<std::istream> stream, size_t buffer_size)
+Reader::Reader(const std::shared_ptr<std::istream>& stream, size_t buffer_size)
 {
-    m_mae_parser.reset(new MaeParser(std::move(stream), buffer_size));
+    m_mae_parser.reset(new MaeParser(stream, buffer_size));
 }
 
 Reader::Reader(const std::string& fname, size_t buffer_size)

--- a/Reader.cpp
+++ b/Reader.cpp
@@ -6,8 +6,9 @@
 #include <boost/iostreams/filtering_stream.hpp>
 
 #include <fstream>
-#include <sstream>
 #include <iostream>
+#include <sstream>
+#include <utility>
 
 using boost::algorithm::ends_with;
 using boost::iostreams::file_source;
@@ -43,7 +44,7 @@ Reader::Reader(const std::string& fname, size_t buffer_size)
         stream.reset(static_cast<std::istream*>(file_stream));
     }
 
-    if(stream->fail()) {
+    if (stream->fail()) {
         std::stringstream ss;
         ss << "Failed to open file \"" << fname << "\" for reading operation.";
         throw std::runtime_error(ss.str());
@@ -52,7 +53,8 @@ Reader::Reader(const std::string& fname, size_t buffer_size)
     m_mae_parser.reset(new MaeParser(stream, buffer_size));
 }
 
-Reader::Reader(std::shared_ptr<MaeParser> mae_parser) : m_mae_parser(mae_parser)
+Reader::Reader(std::shared_ptr<MaeParser> mae_parser)
+    : m_mae_parser(std::move(mae_parser))
 {
 }
 

--- a/Reader.hpp
+++ b/Reader.hpp
@@ -23,7 +23,7 @@ class EXPORT_MAEPARSER Reader
     Reader() = delete;
     Reader(FILE* file, size_t buffer_size = BufferLoader::DEFAULT_SIZE);
 
-    Reader(std::shared_ptr<std::istream> stream,
+    Reader(const std::shared_ptr<std::istream>& stream,
            size_t buffer_size = BufferLoader::DEFAULT_SIZE);
 
     Reader(const std::string& fname,

--- a/Writer.cpp
+++ b/Writer.cpp
@@ -1,27 +1,28 @@
 #include "Writer.hpp"
 
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/iostreams/device/file.hpp>
 #include <boost/iostreams/filter/gzip.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
-#include <boost/iostreams/device/file.hpp>
 
 #include <fstream>
-#include <sstream>
 #include <iostream>
+#include <sstream>
+#include <utility>
 
 #include "MaeBlock.hpp"
 
 using namespace std;
 using boost::algorithm::ends_with;
-using boost::iostreams::filtering_ostream;
 using boost::iostreams::file_sink;
+using boost::iostreams::filtering_ostream;
 
 namespace schrodinger
 {
 namespace mae
 {
 
-Writer::Writer(std::shared_ptr<ostream> stream) : m_out(stream)
+Writer::Writer(std::shared_ptr<ostream> stream) : m_out(std::move(stream))
 {
     write_opening_block();
 }
@@ -40,7 +41,7 @@ Writer::Writer(const std::string& fname)
         m_out.reset(static_cast<ostream*>(file_stream));
     }
 
-    if(m_out->fail()) {
+    if (m_out->fail()) {
         std::stringstream ss;
         ss << "Failed to open file \"" << fname << "\" for writing operation.";
         throw std::runtime_error(ss.str());

--- a/Writer.hpp
+++ b/Writer.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <cstdio>
-#include <string>
 #include <memory>
+#include <string>
 
 #include "MaeParserConfig.hpp"
 

--- a/test/MaeBlockTest.cpp
+++ b/test/MaeBlockTest.cpp
@@ -276,7 +276,7 @@ BOOST_AUTO_TEST_CASE(toStringProperties)
     auto ib = getExampleIndexedBlock();
 
     auto ibm = std::make_shared<mae::IndexedBlockMap>();
-    ibm->addIndexedBlock(ib->getName(), ib);
+    ibm->addIndexedBlock(ib->getName(), std::move(ib));
     b.setIndexedBlockMap(ibm);
 
     BOOST_REQUIRE_EQUAL(b.toString(), rval);


### PR DESCRIPTION
Just what the title says. I did (each in one commit):

-  `clang-tidy -fix -checks='modernize*,-modernize-use-trailing-return-type' *pp -- -std=c++11` (no manual editing).
- The previous command pointed out that deleted constructors and assignments should be public, so I manually moved them into `public:` blocks.
- `clang-tidy -fix -checks='performance*,-modernize-use-trailing-return-type' *pp -- -std=c++11` (no manual editing).

clang-tidy was used from LLVM version 9.0.1. I disabled the "modernize-use-trailing-return-type" because it is annoying (changes function declarations to something like `auto whatever() -> return type`. I also find it slightly annoying that clang-tidy insists on adding `#include <utility>` to the headers, but decided not to remove it.

Checks passed on all three platforms (after bumping MacOS version): https://dev.azure.com/ricrogz/mymaeparser/_build/results?buildId=471