### PR TITLE
Avoid rvalue reference and move for compatibility (#61)

### DIFF
--- a/MaeBlock.hpp
+++ b/MaeBlock.hpp
@@ -70,7 +70,7 @@ class EXPORT_MAEPARSER IndexedBlockMap : public IndexedBlockMapI
      * Add an IndexedBlock to the map.
      */
     void addIndexedBlock(const std::string& name,
-                         std::shared_ptr<IndexedBlock>&& indexed_block)
+                         std::shared_ptr<IndexedBlock> indexed_block)
     {
         m_indexed_block[name] = std::move(indexed_block);
     }
@@ -104,7 +104,7 @@ class EXPORT_MAEPARSER BufferedIndexedBlockMap : public IndexedBlockMapI
      */
     void
     addIndexedBlockBuffer(const std::string& name,
-                          std::shared_ptr<IndexedBlockBuffer>&& block_buffer)
+                          std::shared_ptr<IndexedBlockBuffer> block_buffer)
     {
         m_indexed_buffer[name] = std::move(block_buffer);
     }
@@ -154,7 +154,7 @@ class EXPORT_MAEPARSER Block
     std::shared_ptr<const IndexedBlock>
     getIndexedBlock(const std::string& name) const;
 
-    void addBlock(std::shared_ptr<Block>&& b) { m_sub_block[b->getName()] = b; }
+    void addBlock(std::shared_ptr<Block> b) { m_sub_block[b->getName()] = std::move(b); }
 
     /**
      * Check whether this block has a sub-block of the provided name.

--- a/test/MaeBlockTest.cpp
+++ b/test/MaeBlockTest.cpp
@@ -276,7 +276,7 @@ BOOST_AUTO_TEST_CASE(toStringProperties)
     auto ib = getExampleIndexedBlock();
 
     auto ibm = std::make_shared<mae::IndexedBlockMap>();
-    ibm->addIndexedBlock(ib->getName(), std::move(ib));
+    ibm->addIndexedBlock(ib->getName(), ib);
     b.setIndexedBlockMap(ibm);
 
     BOOST_REQUIRE_EQUAL(b.toString(), rval);


### PR DESCRIPTION
~~#61~~ 2b364d918b60e8227d99d6132e45e1593c218c96 breaks compatibility, leading to compilation failure of [Open Babel](https://github.com/openbabel/openbabel/blob/7684a772e6b60e6b37aa70ad05764d526ab9b00c/src/formats/maeformat.cpp):
```
../src/formats/maeformat.cpp: In member function ‘virtual bool OpenBabel::MAEFormat::WriteMolecule(OpenBabel::OBBase*, OpenBabel::OBConversion*)’:
../src/formats/maeformat.cpp:332:49: error: cannot bind rvalue reference of type ‘std::shared_ptr<schrodinger::mae::IndexedBlock>&&’ to lvalue of type ‘std::shared_ptr<schrodinger::mae::IndexedBlock>’
     ibm->addIndexedBlock(atom_block->getName(), atom_block);
                                                 ^~~~~~~~~~
In file included from ../external/maeparser-master/maeparser/Reader.hpp:8,
                 from ../src/formats/maeformat.cpp:33:
../external/maeparser-master/maeparser/MaeBlock.hpp:72:10: note:   initializing argument 2 of ‘void schrodinger::mae::IndexedBlockMap::addIndexedBlock(const string&, std::shared_ptr<schrodinger::mae::IndexedBlock>&&)’
     void addIndexedBlock(const std::string& name,
          ^~~~~~~~~~~~~~~
../src/formats/maeformat.cpp:333:49: error: cannot bind rvalue reference of type ‘std::shared_ptr<schrodinger::mae::IndexedBlock>&&’ to lvalue of type ‘std::shared_ptr<schrodinger::mae::IndexedBlock>’
     ibm->addIndexedBlock(bond_block->getName(), bond_block);
                                                 ^~~~~~~~~~
In file included from ../external/maeparser-master/maeparser/Reader.hpp:8,
                 from ../src/formats/maeformat.cpp:33:
../external/maeparser-master/maeparser/MaeBlock.hpp:72:10: note:   initializing argument 2 of ‘void schrodinger::mae::IndexedBlockMap::addIndexedBlock(const string&, std::shared_ptr<schrodinger::mae::IndexedBlock>&&)’
     void addIndexedBlock(const std::string& name,
          ^~~~~~~~~~~~~~~
```

To fix this, ~~const reference~~ pass by value and use move instead of rvalue reference.