### PR TITLE
Make sure CMAKE_INSTALL_LIBDIR is defined for non-MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,8 @@ target_include_directories(maeparser PUBLIC
 if(MSVC)
     set(CMAKE_INSTALL_LIBDIR lib)
     set(CMAKE_INSTALL_BINDIR bin)
+else(MSVC)
+    include(GNUInstallDirs)
 endif(MSVC)
 
 install(TARGETS maeparser


### PR DESCRIPTION
I totally missed this when I had a look before: GNUInstallDirs is not always included in *nix systems. E.g., for coordgenlibs (https://github.com/schrodinger/coordgenlibs/pull/74) I noticed the combination MacOs 10.14 plus cmake 3.13.5 did not import it. I think it makes sense to include it here too.