### PR TITLE
Add visibility attribute to import declaration

### DIFF
--- a/MaeParserConfig.hpp
+++ b/MaeParserConfig.hpp
@@ -15,7 +15,7 @@
 #ifdef WIN32
 #define EXPORT_MAEPARSER __declspec(dllimport)
 #else
-#define EXPORT_MAEPARSER
+#define EXPORT_MAEPARSER __attribute__((visibility("default")))
 #endif
 
 #endif

--- a/MaeParserConfig.hpp
+++ b/MaeParserConfig.hpp
@@ -2,26 +2,20 @@
 
 #ifndef STATIC_MAEPARSER
 
-#ifdef IN_MAEPARSER
-
 #ifdef WIN32
+#ifdef IN_MAEPARSER
 #define EXPORT_MAEPARSER __declspec(dllexport)
 #else
-#define EXPORT_MAEPARSER __attribute__((visibility("default")))
-#endif
-
-#else
-
-#ifdef WIN32
 #define EXPORT_MAEPARSER __declspec(dllimport)
-#else
-#define EXPORT_MAEPARSER __attribute__((visibility("default")))
-#endif
+#endif // IN_MAEPARSER
 
-#endif
+#else
+
+#define EXPORT_MAEPARSER __attribute__((visibility("default")))
+#endif // WIN32
 
 #else
 
 #define EXPORT_MAEPARSER
 
-#endif
+#endif // STATIC_MAEPARSER


### PR DESCRIPTION
Apparently, clang doesn't correctly handle type comparisons with mismatched visibility: even if a library is compiled with default visibility, if the code linking it compiles using "hidden" visibility, types won't be correctly matched, creating problems at least in catching exceptions.

This is better explained in the last few comments in rdkit/rdkit/issues/2753. There are also some links to a proof of concept I built to demonstrate the problem with the RDKit.