### PR TITLE
Bump Azure Ubuntu img to 18.04 LTS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,10 +3,10 @@ trigger:
   - dev/*
 
 jobs:
-  - job: Ubuntu_16_04_x64
+  - job: Ubuntu_18_04_x64
     timeoutInMinutes: 90
     pool:
-      vmImage: ubuntu-16.04
+      vmImage: ubuntu-18.04
     variables:
       compiler: gxx_linux-64=7.2.0
       boost_version: 1.67.0
@@ -15,10 +15,10 @@ jobs:
       shared_lib: ON
     steps:
       - template: .azure-pipelines/linux_build.yml
-  - job: Ubuntu_16_04_x64_static
+  - job: Ubuntu_18_04_x64_static
     timeoutInMinutes: 90
     pool:
-      vmImage: ubuntu-16.04
+      vmImage: ubuntu-18.04
     variables:
       compiler: gxx_linux-64=7.2.0
       boost_version: 1.67.0


### PR DESCRIPTION
I was doing some work when I noticed that Azure is retiring the Ubuntu 16.04 image (Support for Ubuntu LTS releases lasts for 5 years, so 16.04 expired last April):
![image](https://user-images.githubusercontent.com/7498185/130321699-b5df5516-bb87-4016-a971-3b4052ba4cb2.png)

I'm replacing it with the next Ubuntu LTS release, 18.04, which will last for another 2 years.