### PR TITLE
Update CI builds

### DIFF
--- a/.azure-pipelines/linux_build.yml
+++ b/.azure-pipelines/linux_build.yml
@@ -7,7 +7,7 @@ steps:
       conda info -a
       conda create --name maeparser_build $(compiler) cmake \
           boost-cpp=$(boost_version) boost=$(boost_version) \
-          libboost=$(boost_version)
+          libboost=$(boost_version) zlib
     displayName: Setup build environment
   - bash: |
       source ${CONDA}/etc/profile.d/conda.sh

--- a/.azure-pipelines/vs_build.yml
+++ b/.azure-pipelines/vs_build.yml
@@ -13,7 +13,7 @@ steps:
       mkdir build && cd build
       call activate maeparser_build
       cmake .. ^
-      -G "Visual Studio 15 2017 Win64" ^
+      -G "Visual Studio 16 2019" ^
       -DCMAKE_BUILD_TYPE=Release ^
       -DMAEPARSER_RIGOROUS_BUILD=ON ^
       -DBoost_NO_SYSTEM_PATHS=ON ^

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,10 +27,10 @@ jobs:
       shared_lib: OFF
     steps:
       - template: .azure-pipelines/linux_build.yml
-  - job: macOS_10_14_x64
+  - job: macOS_10_15_x64
     timeoutInMinutes: 90
     pool:
-      vmImage: macos-10.14
+      vmImage: macos-10.15
     variables:
       compiler: clangxx_osx-64
       boost_version: 1.67.0
@@ -40,10 +40,10 @@ jobs:
       shared_lib: ON
     steps:
       - template: .azure-pipelines/mac_build.yml
-  - job: macOS_10_14_x64_static
+  - job: macOS_10_15_x64_static
     timeoutInMinutes: 90
     pool:
-      vmImage: macos-10.14
+      vmImage: macos-10.15
     variables:
       compiler: clangxx_osx-64
       boost_version: 1.67.0
@@ -53,24 +53,24 @@ jobs:
       shared_lib: OFF
     steps:
       - template: .azure-pipelines/mac_build.yml
-  - job: Windows_VS2017_x64
+  - job: Windows_VS2019_x64
     timeoutInMinutes: 90
     pool:
-      vmImage: vs2017-win2016
+      vmImage: windows-2019
     variables:
-      compiler: vs2017_win-64
+      compiler: vs2019_win-64
       boost_version: 1.67.0
       number_of_cores: "%NUMBER_OF_PROCESSORS%"
       python_name: python37
       shared_lib: ON
     steps:
       - template: .azure-pipelines/vs_build.yml
-  - job: Windows_VS2017_x64_static
+  - job: Windows_VS2019_x64_static
     timeoutInMinutes: 90
     pool:
-      vmImage: vs2017-win2016
+      vmImage: windows-2019
     variables:
-      compiler: vs2017_win-64
+      compiler: vs2019_win-64
       boost_version: 1.67.0
       number_of_cores: "%NUMBER_OF_PROCESSORS%"
       python_name: python37

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,24 +3,24 @@ trigger:
   - dev/*
 
 jobs:
-  - job: Ubuntu_18_04_x64
+  - job: Ubuntu_20_04_x64
     timeoutInMinutes: 90
     pool:
-      vmImage: ubuntu-18.04
+      vmImage: ubuntu-20.04
     variables:
-      compiler: gxx_linux-64=7.2.0
+      compiler: gxx_linux-64
       boost_version: 1.67.0
       number_of_cores: nproc
       python_name: python37
       shared_lib: ON
     steps:
       - template: .azure-pipelines/linux_build.yml
-  - job: Ubuntu_18_04_x64_static
+  - job: Ubuntu_20_04_x64_static
     timeoutInMinutes: 90
     pool:
-      vmImage: ubuntu-18.04
+      vmImage: ubuntu-20.04
     variables:
-      compiler: gxx_linux-64=7.2.0
+      compiler: gxx_linux-64
       boost_version: 1.67.0
       number_of_cores: nproc
       python_name: python37


### PR DESCRIPTION
Our Windows and Mac images were deprecated or directly removed. Ubuntu 18.04 is technically still alive (its a LTS, so it should be on the 5 year cycle), but 22.04 just came out, so it also makes sense to jump to 20.04, which is already 2 years old (especially if we consider the GLIBC issue in memcpy).

These are, basically, the same images RDKit is using now. I'll open another PR for coordgenlibs.