### PR TITLE
Added methods to get names of sub-blocks in mae::Block

### DIFF
--- a/MaeBlock.hpp
+++ b/MaeBlock.hpp
@@ -8,7 +8,6 @@
 #include <string>
 #include <utility>
 
-#include "MaeConstants.hpp"
 #include "MaeParserConfig.hpp"
 
 namespace schrodinger

--- a/MaeBlock.hpp
+++ b/MaeBlock.hpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <utility>
 
+#include "MaeConstants.hpp"
 #include "MaeParserConfig.hpp"
 
 namespace schrodinger
@@ -102,9 +103,8 @@ class EXPORT_MAEPARSER BufferedIndexedBlockMap : public IndexedBlockMapI
      * Add an IndexedBlockBuffer to the map, which can be used to retrieve an
      * IndexedBlock.
      */
-    void
-    addIndexedBlockBuffer(const std::string& name,
-                          std::shared_ptr<IndexedBlockBuffer> block_buffer)
+    void addIndexedBlockBuffer(const std::string& name,
+                               std::shared_ptr<IndexedBlockBuffer> block_buffer)
     {
         m_indexed_buffer[name] = std::move(block_buffer);
     }
@@ -154,7 +154,10 @@ class EXPORT_MAEPARSER Block
     std::shared_ptr<const IndexedBlock>
     getIndexedBlock(const std::string& name) const;
 
-    void addBlock(std::shared_ptr<Block> b) { m_sub_block[b->getName()] = std::move(b); }
+    void addBlock(std::shared_ptr<Block> b)
+    {
+        m_sub_block[b->getName()] = std::move(b);
+    }
 
     /**
      * Check whether this block has a sub-block of the provided name.
@@ -169,7 +172,7 @@ class EXPORT_MAEPARSER Block
     /**
      * Retrieve a shared pointer to the named sub-block.
      */
-    std::shared_ptr<Block> getBlock(const std::string& name)
+    std::shared_ptr<Block> getBlock(const std::string& name) const
     {
         std::map<std::string, std::shared_ptr<Block>>::const_iterator iter =
             m_sub_block.find(name);
@@ -178,6 +181,26 @@ class EXPORT_MAEPARSER Block
         } else {
             return iter->second;
         }
+    }
+
+    /**
+     * Get the names of all non-indexed sub-blocks
+     */
+    std::vector<std::string> getBlockNames() const
+    {
+        std::vector<std::string> names;
+        for (auto& n : m_sub_block) {
+            names.push_back(n.first);
+        }
+        return names;
+    }
+
+    /**
+     * Get the names of all indexed sub-blocks
+     */
+    std::vector<std::string> getIndexedBlockNames() const
+    {
+        return m_indexed_block_map->getBlockNames();
     }
 
     bool operator==(const Block& rhs) const;

--- a/MaeConstants.hpp
+++ b/MaeConstants.hpp
@@ -20,6 +20,7 @@ const char* const BOND_BLOCK = "m_bond";
 const char* const BOND_ATOM_1 = "i_m_from";
 const char* const BOND_ATOM_2 = "i_m_to";
 const char* const BOND_ORDER = "i_m_order";
+const char* const DEPEND_BLOCK = "m_depend";
 
 /**
  * These are the prefixes used to store stereochemical properties in Maestro

--- a/test/subblock_sample.mae
+++ b/test/subblock_sample.mae
@@ -1,0 +1,95 @@
+{
+  s_m_m2io_version
+  :::
+  2.0.0
+}
+
+f_m_ct {
+  s_m_title
+  s_m_entry_id
+  s_m_entry_name
+  i_m_ct_format
+  :::
+  water
+   2
+   water.1
+   2
+  m_atom[3] {
+    # First column is atom index #
+    i_m_mmod_type
+    r_m_x_coord
+    r_m_y_coord
+    r_m_z_coord
+    i_m_residue_number
+    i_m_color
+    s_m_pdb_residue_name
+    s_m_grow_name
+    i_m_atomic_number
+    s_m_color_rgb
+    s_m_atom_name
+    i_m_minimize_atom_index
+    :::
+    1 16 -1.523268 2.566995 0.086033 1 70 "    " "  c1" 8 FF2F2F  O1  1
+    2 42 -2.329434 1.994698 -0.064311 1 21 "    " "  c2" 1 FFFFFF  H2  2
+    3 42 -0.697113 2.013954 -0.021723 1 21 "    " "  n2" 1 FFFFFF  H3  3
+    :::
+  }
+  m_bond[2] {
+    # First column is bond index #
+    i_m_from
+    i_m_to
+    i_m_order
+    i_m_from_rep
+    i_m_to_rep
+    :::
+    1 1 2 1 1 1
+    2 1 3 1 1 1
+    :::
+  }
+  m_test_block {
+    r_test_real
+    i_test_int
+    s_test_string
+    :::
+    0.5
+    1
+    hello
+    m_test_block {
+        i_test_i2
+        :::
+        11
+    }
+    m_test_indexed_block[2] {
+        i_test_ia
+        b_test_bb
+        :::
+        1 101 1
+        2 102 0
+        :::
+    }
+    m_test_repeated_block {
+        i_test_irep
+        :::
+        1001
+    }
+    m_test_repeated_block {
+        i_test_irep
+        :::
+        1002
+    }
+    m_nested_block {
+        i_test_none
+        :::
+        1003
+        m_test_nested_indexed_block[2] {
+            s_test_s1
+            r_test_r2
+            :::
+            1 abc 1.5
+            2 def 0.7
+            :::
+        }
+    }
+  }
+}
+


### PR DESCRIPTION
This is helpful for reading other blocks in our MaeParserReader.