### PR TITLE
modifications to get maeparser building with C++20

### DIFF
--- a/MaeBlock.hpp
+++ b/MaeBlock.hpp
@@ -275,8 +275,8 @@ template <typename T> class IndexedProperty
 
   public:
     // Prevent copying.
-    IndexedProperty<T>(const IndexedProperty<T>&) = delete;
-    IndexedProperty<T>& operator=(const IndexedProperty<T>&) = delete;
+    IndexedProperty(const IndexedProperty<T>&) = delete;
+    IndexedProperty& operator=(const IndexedProperty<T>&) = delete;
 
     using size_type = typename std::vector<T>::size_type;
 
@@ -286,14 +286,14 @@ template <typename T> class IndexedProperty
      *
      * The optional boost::dynamic_bitset is owned by the created object.
      */
-    explicit IndexedProperty<T>(std::vector<T>& data,
+    explicit IndexedProperty(std::vector<T>& data,
                                 boost::dynamic_bitset<>* is_null = nullptr)
         : m_data(), m_is_null(is_null)
     {
         m_data.swap(data);
     }
 
-    ~IndexedProperty<T>()
+    ~IndexedProperty()
     {
         if (m_is_null != nullptr) {
             delete m_is_null;


### PR DESCRIPTION
As-is, maeparser will not compile with g++ using `-std=gnu++20` because `MaeBlock.hpp` has some constructors and destructors which include explicit template information. I'm not sure this was ever required, but it's no longer allowed in C++20.
Here's a stack overflow post with some more details: https://stackoverflow.com/questions/63513984/can-class-template-constructors-have-a-redundant-template-parameter-list-in-c2

The fix is easy and shouldn't affect anything when using older versions of the C++ standard (I've tested back to C++11).

I found this because the RDKit had some of the same fun in it that needed to be cleaned up.