### PR TITLE
Updated property name parsing procedure to allow colons

### DIFF
--- a/MaeParser.cpp
+++ b/MaeParser.cpp
@@ -463,7 +463,6 @@ bool property_key_author_name(Buffer& buffer, char*& save)
     while (buffer.current < buffer.end || buffer.load(save)) {
         switch (*buffer.current) {
         case WHITESPACE:
-        case ':':
         case '{':
         case '[':
             return buffer.current != start;

--- a/test/MaeParserTest.cpp
+++ b/test/MaeParserTest.cpp
@@ -235,15 +235,6 @@ BOOST_AUTO_TEST_CASE(BlockBeginningErrors)
 
 BOOST_AUTO_TEST_CASE(BlockBody)
 {
-    double tolerance = std::numeric_limits<double>::epsilon();
-    {
-        auto ss =
-            std::make_shared<std::stringstream>("b_m_foo b_m_bar::: 1 0 }");
-        MaeParser mp(ss);
-        auto bl = mp.blockBody(CT_BLOCK);
-        BOOST_REQUIRE(bl->getBoolProperty("b_m_foo"));
-        BOOST_REQUIRE(!bl->getBoolProperty("b_m_bar"));
-    }
     {
         auto ss =
             std::make_shared<std::stringstream>(" b_m_foo b_m_bar ::: 1 0 }");
@@ -261,6 +252,7 @@ BOOST_AUTO_TEST_CASE(BlockBody)
         BOOST_REQUIRE(bl->getBoolProperty("b_m_foo"));
         BOOST_REQUIRE(!bl->getBoolProperty("b_m_bar"));
         BOOST_REQUIRE_EQUAL(bl->getStringProperty("s_m_foo"), "svalue");
+        double tolerance = std::numeric_limits<double>::epsilon();
         BOOST_REQUIRE_CLOSE(bl->getRealProperty("r_m_foo"), 3.1415, tolerance);
         BOOST_REQUIRE_EQUAL(bl->getIntProperty("i_m_foo"), 22);
     }


### PR DESCRIPTION
This change fixes a bug that triggered a read_exception when a ':' character was found in a valid property name.

Issue #77