### PR TITLE
Using ZLIB::ZLIB as a CMake package instead of using a path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 set (CMAKE_CXX_STANDARD 11)
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.12)
 
 project(maeparser)
 
@@ -50,7 +50,7 @@ if(MAEPARSER_USE_BOOST_IOSTREAMS)
         message(STATUS "Using Boost zlib module for iostreams dependency.")
     else(Boost_ZLIB_FOUND)
         find_package(ZLIB REQUIRED)
-        set(boost_libs ${boost_libs} ${ZLIB_LIBRARIES})
+        set(boost_libs ${boost_libs} ZLIB::ZLIB)
         message(STATUS "Using zlib library for iostreams dependency.")
     endif(Boost_ZLIB_FOUND)
 


### PR DESCRIPTION
This diff changes CMakeLists.txt so that the linking of the (non-Boost version of) zlib usese the CMake package (`ZLIB::ZLIB`) instead of a CMake variable containing a path (`${ZLIB_LIBRARIES}`).  Using `${ZLIB_LIBRARIES}` causes the build to generate an `maeparser-config.cmake` that contains a hard-coded path to zlib:
```
set_target_properties(maeparser PROPERTIES
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
  INTERFACE_LINK_LIBRARIES "Boost::iostreams;C:/msys64/software/lib/Windows-x64/VS2017/zlib-1.2.11/lib/zlib.lib"
)
```
Because of this, the `maeparser-config.cmake` can't be used on any other machine unless that machine happens to have zlib installed in the exact same place.  This is causing issues for local builds of the new [Sketcher repo](https://github.com/schrodinger/sketcher).  By switching to `ZLIB::ZLIB`, the `maeparser-config.cmake` instead references zlib as `ZLIB::ZLIB`:
```
set_target_properties(maeparser PROPERTIES
  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include"
  INTERFACE_LINK_LIBRARIES "Boost::iostreams;ZLIB::ZLIB"
)
```
As a result, maeparser can be incorporated into other CMake projects regardless of the zlib location via
```
find_package(zlib)
find_package(maeparser)
```

I've also upped the minimum CMake version from 3.5 to 3.12 so that we can control which copy of zlib is found by setting zlib_ROOT.  (See the [CMake documentation](https://cmake.org/cmake/help/latest/variable/PackageName_ROOT.html).)  Since \<PackageName\>_ROOT variables were added in 3.12, they'll be ignored with a warning if the minimum required version is lower than that.

I've successfully done a local build of maeparser with these changes via lib-build-scripts, as well as a local build using CMake directly.