### PR TITLE
Mark Boost/ZLIB link dependencies as PRIVATE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ if(MAEPARSER_USE_BOOST_IOSTREAMS)
         message(STATUS "Using zlib library for iostreams dependency.")
     endif(Boost_ZLIB_FOUND)
 
-    target_link_libraries(maeparser ${boost_libs})
+    target_link_libraries(maeparser PRIVATE ${boost_libs})
 endif(MAEPARSER_USE_BOOST_IOSTREAMS)
 
 SET_TARGET_PROPERTIES (maeparser


### PR DESCRIPTION
After I updated my mac, the rdkit premake stopped working. I have a workaround to the premake file, but claude traced it back to this.

---

Boost::iostreams and ZLIB are implementation details of maeparser — they are not used in any public headers and should not be part of maeparser's cmake interface. Without an explicit scope keyword, `target_link_libraries` defaults to PUBLIC, causing these dependencies to appear in `INTERFACE_LINK_LIBRARIES` in the installed `maeparser-config.cmake`. Downstream consumers then transitively acquire `ZLIB::ZLIB` as a link dependency, and cmake's `FindZLIB` module sets `ZLIB::ZLIB`'s `INTERFACE_INCLUDE_DIRECTORIES` to the SDK's `usr/include`.

This became a breaking issue with the macOS 26.2 → 26.3 system update, which added strict `#error` guards in the 26.3 SDK's libc++ headers (`<cstddef>`, `<cmath>`, etc.). When the SDK's `usr/include` is added as `-isystem`, C system headers (`<math.h>`, `<stddef.h>`) are resolved before the compiler's built-in libc++ wrappers, triggering those guards and breaking C++ stdlib header inclusion in any project that links maeparser.

Adding `PRIVATE` to `target_link_libraries` removes these dependencies from the installed cmake config, so downstream consumers no longer inherit the spurious include path. zlib.h remains accessible to consumers via the sysroot without an explicit `-isystem` path.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)